### PR TITLE
Identity Link Extension

### DIFF
--- a/R/calculate_recommended_interventions.R
+++ b/R/calculate_recommended_interventions.R
@@ -488,6 +488,23 @@ calculate_recommended_interventions <- function(
     stop(paste("'include_time_effects' must be a boolean."))
   }
 
+  if (link == "default") {
+    if (glm_family == "binomial") {
+      link <- "logit"
+    } else if (glm_family == "gaussian") {
+      link <- "identity"
+    }
+  }
+
+  family_object <- switch(
+    glm_family,
+    "binomial" = binomial(link = link),
+    "gaussian" = gaussian(link = link),
+    "quasibinomial" = quasibinomial(link = link),
+    stop(paste("Unsupported glm_family:", glm_family))
+  )
+
+
   # if include_time_effects is set to TRUE
   if (include_time_effects) {
     # the input data must have a 'period' column
@@ -820,12 +837,6 @@ calculate_recommended_interventions <- function(
     ))
   }
 
-  # Convert glm family strings to glm family objects
-  family_object <- switch(glm_family,
-    "binomial" = binomial(link = link),
-    "gaussian" = gaussian(link = link),
-    "quasibinomial" = quasibinomial(link = link),
-  )
 
   # fit the outcome model
   if (input_data_structure == "center_level") {
@@ -950,7 +961,8 @@ calculate_recommended_interventions <- function(
     optimization_grid_search_step_size = optimization_grid_search_step_size,
     center_cha_coeff_vec = center_cha_coeff_vec,
     center_characteristics_optimization_values =
-      center_characteristics_optimization_values
+      center_characteristics_optimization_values,
+    link = link
   )
   message("Done")
 
@@ -1120,3 +1132,19 @@ calculate_recommended_interventions <- function(
     }
   )
 }
+
+calculate_recommended_interventions(
+  data = mtcars,
+  input_data_structure = "individual_level",
+  outcome_name = "mpg",
+  outcome_type = "continuous",
+  glm_family = "gaussian",
+  link = "identity",
+  intervention_components = c("wt"),
+  intervention_lower_bounds = c(0),
+  intervention_upper_bounds = c(1),
+  cost_list_of_vectors = list(c(0, 4)),
+  outcome_goal = 24,
+  confidence_set_grid_step_size = c(1)
+)
+

--- a/R/calculate_recommended_interventions.R
+++ b/R/calculate_recommended_interventions.R
@@ -487,15 +487,6 @@ calculate_recommended_interventions <- function(
   if (!is.logical(include_time_effects)) {
     stop(paste("'include_time_effects' must be a boolean."))
   }
-
-  if (link == "default") {
-    if (glm_family == "binomial") {
-      link <- "logit"
-    } else if (glm_family == "gaussian") {
-      link <- "identity"
-    }
-  }
-
   family_object <- switch(
     glm_family,
     "binomial" = binomial(link = link),
@@ -947,6 +938,7 @@ calculate_recommended_interventions <- function(
   message("Calculating LAGO recommended interventions...")
   # calculate recommended interventions
   rec_int_results <- get_recommended_interventions(
+    link = link,
     intervention_components_coeff = intervention_components_coeff,
     include_interaction_terms = include_interaction_terms,
     main_components = main_components,
@@ -961,8 +953,7 @@ calculate_recommended_interventions <- function(
     optimization_grid_search_step_size = optimization_grid_search_step_size,
     center_cha_coeff_vec = center_cha_coeff_vec,
     center_characteristics_optimization_values =
-      center_characteristics_optimization_values,
-    link = link
+      center_characteristics_optimization_values
   )
   message("Done")
 
@@ -1019,6 +1010,7 @@ calculate_recommended_interventions <- function(
       main_components,
       outcome_data = data[, outcome_name],
       fitted_model = model,
+      link = family_object$link,
       outcome_goal = outcome_goal,
       outcome_type = outcome_type,
       intervention_lower_bounds = intervention_lower_bounds,
@@ -1133,18 +1125,18 @@ calculate_recommended_interventions <- function(
   )
 }
 
-calculate_recommended_interventions(
-  data = mtcars,
-  input_data_structure = "individual_level",
-  outcome_name = "mpg",
-  outcome_type = "continuous",
-  glm_family = "gaussian",
-  link = "identity",
-  intervention_components = c("wt"),
-  intervention_lower_bounds = c(0),
-  intervention_upper_bounds = c(1),
-  cost_list_of_vectors = list(c(0, 4)),
-  outcome_goal = 24,
-  confidence_set_grid_step_size = c(1)
-)
+#calculate_recommended_interventions(
+#  data = mtcars,
+#  input_data_structure = "individual_level",
+#  outcome_name = "mpg",
+#  outcome_type = "continuous",
+#  glm_family = "gaussian",
+#  link = "identity",
+#  intervention_components = c("wt"),
+#  intervention_lower_bounds = c(0),
+#  intervention_upper_bounds = c(1),
+#  cost_list_of_vectors = list(c(0, 4)),
+#  outcome_goal = 24,
+#  confidence_set_grid_step_size = c(1)
+#)
 

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -255,7 +255,6 @@ get_confidence_set <- function(
   # ----------------------------------------------------------------------------
   if (outcome_type == "binary") {
     # TODO: this part needs to handle more than logit link.
-    new_data <- as.matrix(new_data)
     pred_all <- expit(new_data %*% coef(fitted_model))
     se_pred_all <- sqrt(
       diag((new_data) %*% vcov(fitted_model) %*% t(new_data))
@@ -277,7 +276,7 @@ get_confidence_set <- function(
     # ----------------------------------------------------------------------------
   } else if (outcome_type == "continuous") {
     # link is either "binary" or "identity"
-    # If link == "binary", use the old logic (logistic-like) for variance
+    # If link == "logit", use the old logic (logistic-like) for variance
     # If link == "identity", use the identity link logic.
 
     # define the function to manually calculate var-cov matrix

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -116,7 +116,8 @@ get_recommended_interventions <- function(
     optimization_method,
     optimization_grid_search_step_size,
     center_cha_coeff_vec = 0,
-    center_characteristics_optimization_values = 0) {
+    center_characteristics_optimization_values = 0,
+    link = "default") {
   # Function to create a cost function based on coefficients
   # in cost_list_of_vectors
   create_cost_function <- function(coeffs) {
@@ -195,7 +196,7 @@ get_recommended_interventions <- function(
       f_combined <- function(int, main_effects_int) {
         int_vector <- as.numeric(c(1, int))
         # calculate the outcome for this intervention
-        if (link == "binary") {
+        if (link == "logit") {
             outcome <- sum(
               center_weights_for_outcome_goal *
                 expit(
@@ -328,7 +329,7 @@ get_recommended_interventions <- function(
         }
         # negative because NlcOptim minimizes this objective function by default
         return(
-          if (link == "binary") {
+          if (link == "logit") {
             -sum(
               center_weights_for_outcome_goal *
                 expit(

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -117,7 +117,7 @@ get_recommended_interventions <- function(
     optimization_grid_search_step_size,
     center_cha_coeff_vec = 0,
     center_characteristics_optimization_values = 0,
-    link = "default") {
+    link = "identity") {
   # Function to create a cost function based on coefficients
   # in cost_list_of_vectors
   create_cost_function <- function(coeffs) {
@@ -141,7 +141,8 @@ get_recommended_interventions <- function(
                                           center_weights_for_outcome_goal,
                                           center_cha_coeff_vec,
                                           center_cha,
-                                          step_size) {
+                                          step_size,
+                                          link) {
       # create sequence grids for each intervention component
       grids <- lapply(seq_along(cost_params), function(i) {
         seq(lo[i], up[i], by = step_size[i])
@@ -294,7 +295,8 @@ get_recommended_interventions <- function(
                                        all_center_lvl_effects,
                                        center_weights_for_outcome_goal,
                                        center_cha_coeff_vec,
-                                       center_cha) {
+                                       center_cha,
+                                       link) {
       # Objective function to maximize outcome
       # TODO: for now, the objective function is just expit, we will need to
       # make it work with other link functions
@@ -401,18 +403,32 @@ get_recommended_interventions <- function(
           } else {
             int_vector <- c(1, x)
           }
-          f <- rbind(
-            f,
-            outcome_goal -
-              sum(
-                center_weights_for_outcome_goal *
-                  expit(
-                    all_center_lvl_effects +
-                      sum(beta * int_vector) +
-                      center_cha_coeff_vec * center_cha
-                  )
-              )
-          )
+          if (link == "logit") {
+            f <- rbind(
+              f,
+              outcome_goal -
+                sum(
+                  center_weights_for_outcome_goal *
+                    expit(
+                      all_center_lvl_effects +
+                        sum(beta * int_vector) +
+                        center_cha_coeff_vec * center_cha
+                    )
+                )
+            )
+          } else {
+            f <- rbind(
+              f,
+              outcome_goal -
+                sum(
+                  center_weights_for_outcome_goal *
+                      all_center_lvl_effects +
+                        sum(beta * int_vector) +
+                        center_cha_coeff_vec * center_cha
+                )
+            )
+          }
+
           return(list(ceq = NULL, c = f))
         }
 
@@ -452,7 +468,8 @@ get_recommended_interventions <- function(
       all_center_lvl_effects,
       center_weights_for_outcome_goal,
       center_cha_coeff_vec,
-      center_characteristics_optimization_values
+      center_characteristics_optimization_values,
+      link = link
     )
   }
 

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -195,14 +195,24 @@ get_recommended_interventions <- function(
       f_combined <- function(int, main_effects_int) {
         int_vector <- as.numeric(c(1, int))
         # calculate the outcome for this intervention
-        outcome <- sum(
-          center_weights_for_outcome_goal *
-            expit(
-              all_center_lvl_effects +
-                sum(beta * int_vector) +
-                center_cha_coeff_vec * center_cha
+        if (link == "binary") {
+            outcome <- sum(
+              center_weights_for_outcome_goal *
+                expit(
+                  all_center_lvl_effects +
+                    sum(beta * int_vector) +
+                    center_cha_coeff_vec * center_cha
+                )
             )
-        )
+        } else {
+            outcome <- sum(
+              center_weights_for_outcome_goal *
+                  all_center_lvl_effects +
+                    sum(beta * int_vector) +
+                    center_cha_coeff_vec * center_cha
+                )
+        }
+
         # calculate the cost for this intervention
         cost <- sum(mapply(
           function(f, x) f(x),
@@ -317,14 +327,25 @@ get_recommended_interventions <- function(
           int_vector <- c(1, int)
         }
         # negative because NlcOptim minimizes this objective function by default
-        return(-sum(
-          center_weights_for_outcome_goal *
-            expit(
-              all_center_lvl_effects +
+        return(
+          if (link == "binary") {
+            -sum(
+              center_weights_for_outcome_goal *
+                expit(
+                  all_center_lvl_effects +
+                    sum(beta * int_vector) +
+                    center_cha_coeff_vec * center_cha
+                )
+            )
+          } else {
+            -sum(
+              center_weights_for_outcome_goal *
+                all_center_lvl_effects +
                 sum(beta * int_vector) +
                 center_cha_coeff_vec * center_cha
             )
-        ))
+          }
+        )
       }
 
       # get the max achievable outcome

--- a/man/calculate_recommended_interventions.Rd
+++ b/man/calculate_recommended_interventions.Rd
@@ -16,21 +16,21 @@ calculate_recommended_interventions(
   outcome_goal,
   glm_family = "default",
   link = "default",
+  optimization_method = "numerical",
+  confidence_set_alpha = 0.05,
   weights = NULL,
   center_characteristics = NULL,
   center_characteristics_optimization_values = NULL,
-  include_center_effects = NULL,
-  include_time_effects = FALSE,
-  include_interaction_terms = FALSE,
   main_components = NULL,
   time_effect_optimization_value = NULL,
   additional_covariates = NULL,
   center_weights_for_outcome_goal = NULL,
-  optimization_method = "numerical",
   optimization_grid_search_step_size = NULL,
-  include_confidence_set = TRUE,
   confidence_set_grid_step_size = NULL,
-  confidence_set_alpha = 0.05
+  include_confidence_set = TRUE,
+  include_center_effects = FALSE,
+  include_time_effects = FALSE,
+  include_interaction_terms = FALSE
 )
 }
 \arguments{
@@ -88,31 +88,30 @@ Default value without user specification:
 Default value without user specification:
 "identity" for continuous outcomes, "logit" for binary outcomes.}
 
+\item{optimization_method}{A character string. Specifies the method used for
+LAGO optimization. Must be either "numerical" or "grid_search".
+Default value without user specification: "numerical".
+- Use "grid_search" if you want to exhaustively test every possible
+intervention package compositions in LAGO optimization.
+- Use "numerical" if you want to use gradient-based technique in LAGO
+optimization.}
+
+\item{confidence_set_alpha}{A numeric value. The type I error considered in
+the confidence set calculations.
+Default value without user specification: 0.05.}
+
 \item{weights}{A numeric vector. The weights argument of the glm()
 outcome model.}
 
 \item{center_characteristics}{A character vector. The names of the columns in
 the dataset that represent the center characteristics.
+Note, include_center_effects and center_characteristics cannot be used
+together at the same time.
 For example: c("characteristic1")}
 
 \item{center_characteristics_optimization_values}{A numeric vector. The
 values of the center characteristics that will be used for LAGO optimization.
 For example: c(1.74)}
-
-\item{include_center_effects}{A boolean. Specifies whether the fixed effects
-should be included in the outcome model.
-Default value without user specification: FALSE for individual level data,
-TRUE for center level data.}
-
-\item{include_time_effects}{A boolean. Specifies whether the fixed time
-effects should be included in the outcome model.
-Default value without user specification: FALSE.}
-
-\item{include_interaction_terms}{A boolean. Specifies whether there are
-interaction terms in the intervention components. Please make sure the
-interaciton terms are included in "intervention_components", and they
-follow the correct naming scheme: "component1:component3".
-Default value without user specification: FALSE.}
 
 \item{main_components}{A character vector. Specifies the main intervention
 components in the presence of interaction terms.
@@ -136,16 +135,13 @@ For each center, calculate what percentage its sample size is of the total
 samples across all facilities - this percentage serves as that
 center's weight.}
 
-\item{optimization_method}{A character string. Specifies the method used for
-LAGO optimization. Must be either "numerical" or "grid_search".
-Default value without user specification: "numerical".
-- Use "grid_search" if you want to exhaustively test every possible
-intervention package compositions in LAGO optimization.
-- Use "numerical" if you want to use gradient-based technique in LAGO
-optimization.}
-
 \item{optimization_grid_search_step_size}{A numeric vector. Specifies the
 step size of the grid search algorithm used in LAGO optimization.
+Default value without user specification:
+1/20 of the range for each intervention component.}
+
+\item{confidence_set_grid_step_size}{A numeric vector. Specifies the step
+size of the grid search algorithm used in the confidence set calculation.
 Default value without user specification:
 1/20 of the range for each intervention component.}
 
@@ -153,14 +149,25 @@ Default value without user specification:
 should be calculated along with the recommended interventions.
 Default value without user specification: TRUE.}
 
-\item{confidence_set_grid_step_size}{A numeric vector. Specifies the step
-size of the grid search algorithm used in the confidence set calculation.
-Default value without user specification:
-1/20 of the range for each intervention component.}
+\item{include_center_effects}{A boolean. Specifies whether the fixed effects
+should be included in the outcome model. If set to TRUE, please make sure
+that the input data has a 'center' column to identify the centers.
+Note, include_center_effects and center_characteristics cannot be used
+together at the same time.
+Default value without user specification: FALSE for individual level data,
+TRUE for center level data.}
 
-\item{confidence_set_alpha}{A numeric value. The type I error considered in
-the confidence set calculations.
-Default value without user specification: 0.05.}
+\item{include_time_effects}{A boolean. Specifies whether the fixed time
+effects should be included in the outcome model. If set to TRUE, please
+make sure that the input data has a 'period' column to identify the time
+periods.
+Default value without user specification: FALSE.}
+
+\item{include_interaction_terms}{A boolean. Specifies whether there are
+interaction terms in the intervention components. Please make sure the
+interaciton terms are included in "intervention_components", and they
+follow the correct naming scheme: "component1:component3".
+Default value without user specification: FALSE.}
 }
 \value{
 List(

--- a/manual_tests/test_pulesa_cost_related.Rmd
+++ b/manual_tests/test_pulesa_cost_related.Rmd
@@ -28,9 +28,9 @@ devtools::load_all()
 #
 # code below are shared by Jingyu:
 # 
-setwd("/Users/antebing/Library/CloudStorage/Dropbox/LAGO r package paper/Optimization R code-Jingyu")
+#setwd("/Users/antebing/Library/CloudStorage/Dropbox/LAGO r package paper/Optimization R code-Jingyu")
 
-original_data<-read.csv("data_all_patients_complete_cumulative (selected).csv", header = TRUE, sep = ',', encoding = "UTF-8")
+original_data<-read.csv("/Users/minhthubui/Desktop/data_all_patients_complete_cumulative (selected).csv", header = TRUE, sep = ',', encoding = "UTF-8")
 
 original_data<-original_data[,c(-6, -14: -16)]
 
@@ -135,17 +135,17 @@ coef_clinic_all<-c(-2.758192, -1.973129, -1.999936, -2.077562,
 ```{r}
 # 
 library(readr)
-data_all_patients_complete <- read_csv("data_all_patients_complete_cumulative (selected).csv")
+data_all_patients_complete <- read_csv("/Users/minhthubui/Desktop/data_all_patients_complete_cumulative (selected).csv")
 
 weights_all<-sapply(unique(data_all_patients_complete$Clinics), 
                     FUN = function(x) sum(data_all_patients_complete$`Total visits (no restrictions)`[data_all_patients_complete$Clinics==x]))/sum(data_all_patients_complete$`Total visits (no restrictions)`)
-data_hypertensive_complete_data <- read_csv("data_hypertensive_complete_cumulative (selected).csv")
+data_hypertensive_complete_data <- read_csv("/Users/minhthubui/Desktop/data_hypertensive_complete_cumulative (selected).csv")
 weights_hypertension<-sapply(unique(data_hypertensive_complete_data$Clinics), FUN = function(x) sum(data_hypertensive_complete_data$`Total visits (all hypertensive without restrictions)`[data_hypertensive_complete_data$Clinics==x]))/sum(data_hypertensive_complete_data$`Total visits (all hypertensive without restrictions)`)
 
 avg_n_all_patients<-sum(data_all_patients_complete$`Total visits (no restrictions)`, na.rm = T)/12
 avg_n_hypertension_patients<-sum(data_hypertensive_complete_data$`Total visits (all hypertensive without restrictions)`, na.rm = T)/12
 n_providers_permonth<-233.33
-data_n_drugs_dispensed <- read_csv("PULESA data with interventions_4292024.csv")
+data_n_drugs_dispensed <- read_csv("/Users/minhthubui/Desktop/PULESA data with interventions_4292024.csv")
 n_patients_drugs_dispensed_permonth<-sum(data_n_drugs_dispensed$`Number with medication Dispensed`)/12
 
 

--- a/manual_tests/test_rec_int_for_BB_data_cts.Rmd
+++ b/manual_tests/test_rec_int_for_BB_data_cts.Rmd
@@ -176,3 +176,6 @@ optimization_results <- calculate_recommended_interventions(
   include_confidence_set = TRUE
 )
 ```
+
+
+

--- a/manual_tests/test_rec_int_for_cts_identity.Rmd
+++ b/manual_tests/test_rec_int_for_cts_identity.Rmd
@@ -14,18 +14,17 @@ devtools::load_all()
 
 ```{r}
 calculate_recommended_interventions(
-   data = mtcars,
-   input_data_structure = "individual_level",
-   outcome_name = "mpg",
-   outcome_type = "continuous",
-   glm_family = "gaussian",
-   link = "identity",
-   intervention_components = c("wt", "hp"),
-   intervention_lower_bounds = c(0, 0),
-   intervention_upper_bounds = c(10, 350),
-   cost_list_of_vectors = list(c(0, 4), c(4, 6)),
-   outcome_goal = 24,
-   confidence_set_grid_step_size = c(1, 1)
+  data = mtcars,
+  input_data_structure = "individual_level",
+  outcome_name = "mpg",
+  outcome_type = "continuous",
+  glm_family = "gaussian",
+  link = "identity",
+  intervention_components = c("gear", "qsec"),
+  intervention_lower_bounds = c(0, 0),
+  intervention_upper_bounds = c(10, 350),
+  cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+  outcome_goal = 40,
+  confidence_set_grid_step_size = c(1, 1)
 )
-
 ```

--- a/manual_tests/test_rec_int_for_cts_identity.Rmd
+++ b/manual_tests/test_rec_int_for_cts_identity.Rmd
@@ -1,0 +1,31 @@
+---
+title: "Manual test calculations of the recommended interventions with mtcars with continuous outcome and identity link."
+output: pdf_document
+date: "`r Sys.Date()`"
+author: "Minh Bui"
+editor_options: 
+  chunk_output_type: console
+---
+```{r}
+devtools::clean_dll()
+devtools::load_all()
+```
+
+
+```{r}
+calculate_recommended_interventions(
+   data = mtcars,
+   input_data_structure = "individual_level",
+   outcome_name = "mpg",
+   outcome_type = "continuous",
+   glm_family = "gaussian",
+   link = "identity",
+   intervention_components = c("wt", "hp"),
+   intervention_lower_bounds = c(0, 0),
+   intervention_upper_bounds = c(10, 350),
+   cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+   outcome_goal = 24,
+   confidence_set_grid_step_size = c(1, 1)
+)
+
+```

--- a/manual_tests/test_rec_int_for_cts_identity.Rmd
+++ b/manual_tests/test_rec_int_for_cts_identity.Rmd
@@ -28,3 +28,65 @@ calculate_recommended_interventions(
   confidence_set_grid_step_size = c(1, 1)
 )
 ```
+
+```{r}
+# grid search
+calculate_recommended_interventions(
+  data = mtcars,
+  input_data_structure = "individual_level",
+  outcome_name = "mpg",
+  outcome_type = "continuous",
+  glm_family = "gaussian",
+  link = "identity",
+  intervention_components = c("gear", "qsec"),
+  intervention_lower_bounds = c(0, 0),
+  intervention_upper_bounds = c(10, 350),
+  cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+  outcome_goal = 40,
+  confidence_set_grid_step_size = c(1, 1),
+  optimization_method = "grid_search",
+  optimization_grid_search_step_size = c(1, 1)
+)
+```
+
+
+```{r}
+# higher order cost function
+# check if it is possible to get recommended interventions to be not
+# on the boundary
+calculate_recommended_interventions(
+  data = mtcars,
+  input_data_structure = "individual_level",
+  outcome_name = "mpg",
+  outcome_type = "continuous",
+  glm_family = "gaussian",
+  link = "identity",
+  intervention_components = c("gear", "qsec"),
+  intervention_lower_bounds = c(0, 0),
+  intervention_upper_bounds = c(20, 20),
+  cost_list_of_vectors = list(c(0, 4, 8), c(4, 6, 5)),
+  outcome_goal = 40,
+  confidence_set_grid_step_size = c(1, 1)
+)
+```
+
+```{r}
+# higher order cost function
+# grid search
+calculate_recommended_interventions(
+  data = mtcars,
+  input_data_structure = "individual_level",
+  outcome_name = "mpg",
+  outcome_type = "continuous",
+  glm_family = "gaussian",
+  link = "identity",
+  intervention_components = c("gear", "qsec"),
+  intervention_lower_bounds = c(0, 0),
+  intervention_upper_bounds = c(20, 20),
+  cost_list_of_vectors = list(c(0, 4, 8), c(4, 6, 5)),
+  outcome_goal = 40,
+  confidence_set_grid_step_size = c(1, 1),
+  optimization_method = "grid_search",
+  optimization_grid_search_step_size = c(1, 1)
+)
+```


### PR DESCRIPTION
I made an extension to include the identity link in the get_recommended_intervention and get_confidence_intervals files. I couldn't create a manual test for this because when I ran the original manual tests for PULESA, I kept running into the issue of center weights not adding up to 1. Please review and let me know what you think. 