### PR TITLE
add CI and cost to the confidence set

### DIFF
--- a/R/calculate_recommended_interventions.R
+++ b/R/calculate_recommended_interventions.R
@@ -275,7 +275,8 @@ calculate_recommended_interventions <- function(
       intervention_upper_bounds = intervention_upper_bounds,
       center_characteristics_optimization_values =
         center_characteristics_optimization_values,
-      confidence_set_alpha = confidence_set_alpha
+      confidence_set_alpha = confidence_set_alpha,
+      cost_list_of_vectors = cost_list_of_vectors
     )
 
     # unpack the confidence set results to the environment

--- a/R/confidence_set_processor.R
+++ b/R/confidence_set_processor.R
@@ -19,7 +19,8 @@ confidence_set_processor <- function(
     intervention_lower_bounds,
     intervention_upper_bounds,
     center_characteristics_optimization_values,
-    confidence_set_alpha) {
+    confidence_set_alpha,
+    cost_list_of_vectors) {
     # assign confidence set step size if not specified
     if (include_confidence_set && is.null(confidence_set_grid_step_size)) {
         confidence_set_grid_step_size <- step_size_results
@@ -78,7 +79,8 @@ confidence_set_processor <- function(
             center_characteristics_optimization_values =
                 center_characteristics_optimization_values,
             confidence_set_alpha = confidence_set_alpha,
-            cluster_id = cluster_id
+            cluster_id = cluster_id,
+            cost_list_of_vectors
         )
         message("Done")
 

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -570,8 +570,8 @@ get_confidence_set <- function(
   }
 
   cs_output_names <- names(cs)
-  if (outcome_type == "continuous" && link == "identity" ||
-    outcome_type == "binary") {
+  if ((outcome_type == "continuous" && link == "identity") ||
+    (outcome_type == "binary")) {
     CI_lower_bound <- round(lb_prob_all[cs_row_indices], 3)
     CI_upper_bound <- round(ub_prob_all[cs_row_indices], 3)
   } else {

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -46,6 +46,8 @@
 #' the confidence set calculations.
 #' @param cluster_id A list or NULL. Specifies the columns of data that will be
 #' used as clustering effects when the "outcome_type" is continuous.
+#' @param cost_list_of_vectors A list of numeric vectors. The cost vectors
+#' used in the LAGO optimization.
 #'
 #' @return List(
 #'   confidence_set_size_percentage = <number>,
@@ -77,7 +79,8 @@ get_confidence_set <- function(
     center_characteristics = NULL,
     center_characteristics_optimization_values = 0,
     confidence_set_alpha = 0.05,
-    cluster_id = NULL) {
+    cluster_id = NULL,
+    cost_list_of_vectors) {
   # Create a list to store sequences for each component
   sequences <- list()
   # Generate sequences for each intervention component
@@ -232,6 +235,8 @@ get_confidence_set <- function(
     lb_prob_all <- pred_all - critical_value * se_pred_all
     ub_prob_all <- pred_all + critical_value * se_pred_all
     ci_prob_all <- cbind(lb_prob_all, ub_prob_all)
+    print("ci prob all:")
+    print(ci_prob_all[1:25, ])
 
     # calculate percentage of interventions
     # that are included in the confidence set
@@ -541,11 +546,54 @@ get_confidence_set <- function(
     }
   )]
 
+  create_cost_function <- function(coeffs) {
+    function(x) {
+      sum(sapply(seq_along(coeffs), function(i) coeffs[i] * x^(i - 1)))
+    }
+  }
+  cost_functions <- lapply(cost_list_of_vectors, create_cost_function)
+  row_costs <- data.frame(
+    row.names = rownames(cs),
+    total_cost = apply(cs, 1, function(row) {
+      sum(mapply(
+        function(cost_fn, value) cost_fn(value),
+        cost_functions,
+        row
+      ))
+    })
+  )
+
   if (length(center_characteristics) > 0) {
     original_cs_name <- names(cs)
     cs <- cbind(cs, center_characteristics_optimization_values)
     names(cs) <- c(original_cs_name, center_characteristics)
   }
+
+  cs_output_names <- names(cs)
+  if (outcome_type == "continuous" && link == "identity" ||
+    outcome_type == "binary") {
+    CI_lower_bound <- round(lb_prob_all[cs_row_indices], 3)
+    CI_upper_bound <- round(ub_prob_all[cs_row_indices], 3)
+  } else {
+    CI_lower_bound <- round(expit(lb_prob_all[cs_row_indices]), 3)
+    CI_upper_bound <- round(expit(ub_prob_all[cs_row_indices]), 3)
+  }
+
+  cs <- cbind(
+    cs,
+    round(CI_lower_bound, 3),
+    round(CI_upper_bound, 3)
+  )
+  cs <- cbind(
+    cs,
+    round(row_costs, 2)
+  )
+  names(cs) <- c(
+    cs_output_names,
+    "CI_lower_bound",
+    "CI_upper_bound",
+    "cost"
+  )
 
   return(list(
     confidence_set_size_percentage = confidence_set_size_percentage,

--- a/man/get_confidence_set.Rd
+++ b/man/get_confidence_set.Rd
@@ -24,7 +24,8 @@ get_confidence_set(
   center_characteristics = NULL,
   center_characteristics_optimization_values = 0,
   confidence_set_alpha = 0.05,
-  cluster_id = NULL
+  cluster_id = NULL,
+  cost_list_of_vectors
 )
 }
 \arguments{
@@ -90,6 +91,9 @@ the confidence set calculations.}
 
 \item{cluster_id}{A list or NULL. Specifies the columns of data that will be
 used as clustering effects when the "outcome_type" is continuous.}
+
+\item{cost_list_of_vectors}{A list of numeric vectors. The cost vectors
+used in the LAGO optimization.}
 }
 \value{
 List(


### PR DESCRIPTION
add 95% CI and cost associated for each row of the confidence set. 
please note that I refactored a lot of code from `calculate_recommended_intervention.R`, so that function is a lot cleaner now. I didn't ask for your review for the refactoring PRs as the code pretty much stayed the same. 

To test, I ran all of the Rmd files (except `test_pulesa_cost_related` which i haven't got to it yet), and the results look correct to me. 