### PR TITLE
Support standalone power goal in lago_optimization()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: LAGO
 Type: Package
 Title: LAGO
-Version: 1.0.11
+Version: 1.0.12
 Author: Ante Bing, Minh Bui, Jingyu Cui
 Maintainer: Ante Bing <abing@bu.edu>
 Description: Calculates LAGO recommended interventions for the next stage.

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -528,10 +528,12 @@ get_confidence_set <- function(
     function(y) findInterval(x = outcome_goal, vec = y)
   ) == 1) == 1)
 
-  # if there is only one row in the confidence set, it means
-  # that the recommended intervention (the first row) is
-  # the only intervention in the confidence set
-  if (length(cs_row_indices) == 1) {
+  # if there is at most one row in the confidence set, it means the
+  # recommended intervention (the first row) is the only intervention in the
+  # confidence set (== 1), or not even the recommended intervention's
+  # confidence interval covers the outcome goal (== 0). In either case there
+  # is no confidence set to report.
+  if (length(cs_row_indices) <= 1) {
     return(list(
       confidence_set_size_percentage = 0,
       cs = NULL

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -605,7 +605,13 @@ get_recommended_interventions <- function(
     # the effective outcome goal actually used for optimization:
     # max(power-implied outcome, outcome_goal). Equals outcome_goal when
     # no power goal is set, and the power-implied outcome when only a
-    # power goal is set. Surfaced so the confidence set can use it.
-    effective_outcome_goal = new_outcome_goal
+    # power goal is set. Reported on the original outcome scale (re-negated
+    # for the "minimize" case, mirroring est_reachable_outcome) so downstream
+    # consumers such as the confidence set and printout can use it directly.
+    effective_outcome_goal = if (lower_outcome_goal) {
+      -1 * new_outcome_goal
+    } else {
+      new_outcome_goal
+    }
   ))
 }

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -282,7 +282,7 @@ get_recommended_interventions <- function(
           lo = lo,
           up = up,
           beta = beta,
-          outcome_goal = outcome_goal,
+          outcome_goal = new_outcome_goal,
           include_interaction_terms = include_interaction_terms,
           intervention_components = intervention_components,
           main_components = main_components,
@@ -537,7 +537,7 @@ get_recommended_interventions <- function(
           lo = lo,
           up = up,
           beta = beta,
-          outcome_goal = outcome_goal,
+          outcome_goal = new_outcome_goal,
           include_interaction_terms = include_interaction_terms,
           intervention_components = intervention_components,
           main_components = main_components,
@@ -598,6 +598,11 @@ get_recommended_interventions <- function(
     est_rec_int = opt_results$est_rec_int,
     rec_int_cost = opt_results$rec_int_cost,
     est_reachable_outcome = opt_results$est_reachable_outcome,
-    shrinking_method_used = opt_results$shrinking_method_used
+    shrinking_method_used = opt_results$shrinking_method_used,
+    # the effective outcome goal actually used for optimization:
+    # max(power-implied outcome, outcome_goal). Equals outcome_goal when
+    # no power goal is set, and the power-implied outcome when only a
+    # power goal is set. Surfaced so the confidence set can use it.
+    effective_outcome_goal = new_outcome_goal
   ))
 }

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -79,10 +79,13 @@
 #' variable in the dataset.
 #'
 #' @return List(
-#' recommended interventions,
-#' outcome goal,
-#' estimated outcome mean/probability for the intervention
-#' group in the next stage )
+#' est_rec_int = recommended interventions,
+#' rec_int_cost = associated cost of the recommended interventions,
+#' est_reachable_outcome = estimated outcome mean/probability for the
+#' intervention group in the next stage,
+#' shrinking_method_used = whether the shrinking method was applied,
+#' effective_outcome_goal = the outcome goal actually used for optimization,
+#' i.e. max(power-implied outcome, outcome_goal) )
 #'
 #'
 #' @importFrom rje expit logit

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -365,6 +365,17 @@ lago_optimization <- function(
   # calculate the confidence set
   if (include_confidence_set) {
     cli::cli_alert_info("Calculating the confidence set...")
+    # the confidence set is computed on the original (un-negated) model, so it
+    # needs the outcome goal on the original scale. When an outcome goal is
+    # provided, use it directly (this is also correct for the "minimize" case,
+    # where effective_outcome_goal is on the negated scale). Only when there is
+    # no outcome goal (power goal alone, always "maximize") do we fall back to
+    # the power-implied effective goal.
+    confidence_set_outcome_goal <- if (!is.null(outcome_goal)) {
+      outcome_goal
+    } else {
+      effective_outcome_goal
+    }
     cs_results <- confidence_set_processor(
       data = data,
       confidence_set_grid_step_size = confidence_set_grid_step_size,
@@ -380,7 +391,7 @@ lago_optimization <- function(
       outcome_name = outcome_name,
       model = model,
       family_object = family_object,
-      outcome_goal = effective_outcome_goal,
+      outcome_goal = confidence_set_outcome_goal,
       outcome_type = outcome_type,
       intervention_lower_bounds = intervention_lower_bounds,
       intervention_upper_bounds = intervention_upper_bounds,

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -24,10 +24,18 @@
 #' c(10,20).
 #' @param outcome_goal A numeric value. Specifies the outcome goal, a desired
 #' probability or mean value.
+#' Default value without user specification: NULL.
+#' At least one of outcome_goal or power_goal must be provided. If only a
+#' power goal is provided, the optimization target is the outcome level needed
+#' to achieve the power goal. If both are provided, the effective outcome goal
+#' is the higher of the two (see power_goal).
 #' @param outcome_goal_intention A character string. Specifies the intention of
 #' the outcome goal. Must be either "maximize" or "minimize". If the goal is to
 #' increase the outcome, set it to "maximize". If the goal is to decrease the
 #' outcome, set it to "minimize".
+#' Default value without user specification: "maximize".
+#' Note: "minimize" cannot be combined with a power goal, because achieving a
+#' power goal requires increasing the outcome.
 #'
 #' @param unit_costs A numeric vector. Specifies the unit costs for each
 #' intervention component.
@@ -144,7 +152,14 @@
 #' shrinkage method will not be used.
 #' Default value without user specification: 0.25.
 #' @param power_goal A numeric value. Specifies the power goal, a desired power
-#' value.
+#' value (between 0 and 1). Only supported for binary outcomes, and requires a
+#' 'group' column (values "treatment"/"control") along with
+#' num_centers_in_next_stage and patients_per_center_in_next_stage.
+#' At least one of outcome_goal or power_goal must be provided. The power goal
+#' is converted into the outcome level needed to achieve that power; the
+#' effective outcome goal used for optimization is
+#' max(power-implied outcome, outcome_goal). When only a power goal is
+#' provided, the power-implied outcome is used directly.
 #' Default value without user specification: NULL.
 #' @param power_goal_approach A character string. Specifies the approach to
 #' achieve the power goal. Must be either "unconditional" or "conditional".
@@ -225,8 +240,8 @@ lago_optimization <- function(
     intervention_components,
     intervention_lower_bounds,
     intervention_upper_bounds,
-    outcome_goal,
-    outcome_goal_intention,
+    outcome_goal = NULL,
+    outcome_goal_intention = "maximize",
     power_goal = NULL,
     power_goal_approach = "unconditional",
     num_centers_in_next_stage = NULL,
@@ -365,7 +380,7 @@ lago_optimization <- function(
       outcome_name = outcome_name,
       model = model,
       family_object = family_object,
-      outcome_goal = outcome_goal,
+      outcome_goal = effective_outcome_goal,
       outcome_type = outcome_type,
       intervention_lower_bounds = intervention_lower_bounds,
       intervention_upper_bounds = intervention_upper_bounds,
@@ -411,6 +426,8 @@ lago_optimization <- function(
     include_center_effects = include_center_effects,
     include_time_effects = include_time_effects,
     outcome_goal = outcome_goal,
+    power_goal = power_goal,
+    effective_outcome_goal = effective_outcome_goal,
     cost_list_of_vectors = cost_list_of_vectors,
     intervention_lower_bounds = intervention_lower_bounds,
     intervention_upper_bounds = intervention_upper_bounds,
@@ -436,7 +453,8 @@ lago_optimization <- function(
         rec_int_cost = rec_int_cost,
         est_outcome_goal = est_outcome_goal,
         confidence_set_size_percentage = cs$confidence_set_size_percentage,
-        cs = cs$cs[-1, ]
+        # cs$cs is NULL when no confidence set was found for the goal
+        cs = if (is.null(cs$cs)) NULL else cs$cs[-1, ]
       )
     }
   )

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -365,17 +365,14 @@ lago_optimization <- function(
   # calculate the confidence set
   if (include_confidence_set) {
     cli::cli_alert_info("Calculating the confidence set...")
-    # the confidence set is computed on the original (un-negated) model, so it
-    # needs the outcome goal on the original scale. When an outcome goal is
-    # provided, use it directly (this is also correct for the "minimize" case,
-    # where effective_outcome_goal is on the negated scale). Only when there is
-    # no outcome goal (power goal alone, always "maximize") do we fall back to
-    # the power-implied effective goal.
-    confidence_set_outcome_goal <- if (!is.null(outcome_goal)) {
-      outcome_goal
-    } else {
-      effective_outcome_goal
-    }
+    # the confidence set is built around the outcome goal the recommendation
+    # actually targets, i.e. the effective goal max(power-implied, outcome_goal).
+    # effective_outcome_goal is reported on the original outcome scale (already
+    # re-negated for the "minimize" case), and the confidence set uses the
+    # original, un-negated model, so it can be used directly here. This keeps
+    # the confidence set, the recommended intervention, and the reported
+    # estimated outcome goal all consistent with the same target.
+    confidence_set_outcome_goal <- effective_outcome_goal
     cs_results <- confidence_set_processor(
       data = data,
       confidence_set_grid_step_size = confidence_set_grid_step_size,

--- a/R/print_output.R
+++ b/R/print_output.R
@@ -10,6 +10,8 @@ print_output <- function(
     include_center_effects,
     include_time_effects,
     outcome_goal,
+    power_goal = NULL,
+    effective_outcome_goal = NULL,
     cost_list_of_vectors,
     intervention_lower_bounds,
     intervention_upper_bounds,
@@ -56,7 +58,20 @@ print_output <- function(
   cat("\t link:", family_object$link, "\n")
   cat("\t fixed center effects:", include_center_effects, "\n")
   cat("\t fixed time effects:", include_time_effects, "\n")
-  cat("Outcome goal:", outcome_goal, "\n")
+  cat(
+    "Outcome goal:",
+    if (is.null(outcome_goal)) "not specified" else outcome_goal, "\n"
+  )
+  cat(
+    "Power goal:",
+    if (is.null(power_goal)) "not specified" else power_goal, "\n"
+  )
+  if (!is.null(power_goal)) {
+    cat(
+      "Effective outcome goal used (max of outcome goal and",
+      "power-implied outcome):", effective_outcome_goal, "\n"
+    )
+  }
   cat(
     "List of intervention component costs:",
     toString(cost_list_of_vectors), "\n"
@@ -112,8 +127,10 @@ print_output <- function(
   )
   cat(
     "95% confidence interval for the estimated outcome goal:",
-    if (include_confidence_set) {
+    if (include_confidence_set && !is.null(cs$cs)) {
       paste(cs$cs[1, ]$CI_lower_bound, "-", cs$cs[1, ]$CI_upper_bound)
+    } else if (include_confidence_set) {
+      "Not available (no confidence set found for the current goal)"
     } else {
       "Not available, please set include_confidence_set = TRUE"
     }, "\n"

--- a/R/rec_int_processor.R
+++ b/R/rec_int_processor.R
@@ -123,6 +123,7 @@ rec_int_processor <- function(
     rec_int_cost = rec_int_results$rec_int_cost,
     est_outcome_goal = rec_int_results$est_reachable_outcome,
     step_size_results = step_size_results,
-    shrinking_method_used = rec_int_results$shrinking_method_used
+    shrinking_method_used = rec_int_results$shrinking_method_used,
+    effective_outcome_goal = rec_int_results$effective_outcome_goal
   )
 }

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -888,8 +888,9 @@ validate_inputs <- function(
       stop("For now, the power goal only works with binary outcomes.")
     }
     # a power goal requires increasing the outcome to reach the desired
-    # power, so it is incompatible with minimizing the outcome.
-    if (!is.null(outcome_goal) && outcome_goal_intention == "minimize") {
+    # power, so it is incompatible with minimizing the outcome. This holds
+    # whether or not an outcome goal is also provided.
+    if (outcome_goal_intention == "minimize") {
       stop(paste(
         "A power goal cannot be combined with",
         "outcome_goal_intention = 'minimize', because achieving a power",

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -711,8 +711,19 @@ validate_inputs <- function(
     }
   }
 
-  # check if the outcome goal is a numeric number
-  if (!is.numeric(outcome_goal)) {
+  # at least one of outcome_goal or power_goal must be provided. LAGO
+  # optimization supports three modes: outcome goal alone, power goal alone,
+  # or both together (in which case the effective goal is the higher of the
+  # two, see get_recommended_interventions()).
+  if (is.null(outcome_goal) && is.null(power_goal)) {
+    stop(paste(
+      "Both 'outcome_goal' and 'power_goal' are NULL.",
+      "Please provide at least one of them."
+    ))
+  }
+
+  # check if the outcome goal is a numeric number (only when provided)
+  if (!is.null(outcome_goal) && !is.numeric(outcome_goal)) {
     stop("The outcome goal must be a numeric value.")
   }
 
@@ -732,8 +743,13 @@ validate_inputs <- function(
   }
 
   # set the lower_outcome_goal flag accordingly
-  # check the average outcome and print warning messages
-  if (outcome_goal_intention == "minimize") {
+  # check the average outcome and print warning messages.
+  # when only a power goal is provided (outcome_goal is NULL), the goal is
+  # always to increase the outcome to reach the desired power, so
+  # lower_outcome_goal is FALSE and the intention checks are skipped.
+  if (is.null(outcome_goal)) {
+    lower_outcome_goal <- FALSE
+  } else if (outcome_goal_intention == "minimize") {
     lower_outcome_goal <- TRUE
     if (outcome_goal > mean(data[[outcome_name]])) {
       warning(paste(
@@ -870,6 +886,16 @@ validate_inputs <- function(
     # check if the outcome_type is binary
     if (outcome_type != "binary") {
       stop("For now, the power goal only works with binary outcomes.")
+    }
+    # a power goal requires increasing the outcome to reach the desired
+    # power, so it is incompatible with minimizing the outcome.
+    if (!is.null(outcome_goal) && outcome_goal_intention == "minimize") {
+      stop(paste(
+        "A power goal cannot be combined with",
+        "outcome_goal_intention = 'minimize', because achieving a power",
+        "goal requires increasing the outcome. Please set",
+        "outcome_goal_intention = 'maximize', or remove the power goal."
+      ))
     }
     # check if there is a 'group' column in the data
     # and it is either "treatment" or "control"

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -10,6 +10,7 @@
     "rec_int",
     "rec_int_cost",
     "est_outcome_goal",
+    "effective_outcome_goal",
     "cs",
     "x",
     "y"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The LAGO R package has two user-facing functions `lago_optimization()` and `visu
 
 `lago_optimization()` carries out the LAGO optimizations, and `visualize_cost()` helps users to determine the cost function of intervention components.
 
+`lago_optimization()` supports three goal modes: an **outcome goal alone**, a **power goal alone**, or **both together**. At least one of `outcome_goal` or `power_goal` must be provided. When both are provided, the effective outcome goal used for the optimization is the higher of the outcome goal and the outcome level implied by the power goal (the "whichever is higher" rule). A power goal is only supported for binary outcomes and requires a `group` column plus `num_centers_in_next_stage` and `patients_per_center_in_next_stage`; it cannot be combined with `outcome_goal_intention = "minimize"`.
+
 Both functions have multiple arguments, and it is impractical to list them all here.
 To get a better understanding of the input arguments, please take a look at the help files by running the following code in R **(this step is HIGHLY recommended, please do this before moving on to the examples)**:
 ```

--- a/man/get_recommended_interventions.Rd
+++ b/man/get_recommended_interventions.Rd
@@ -132,10 +132,13 @@ variable in the dataset.}
 }
 \value{
 List(
-recommended interventions,
-outcome goal,
-estimated outcome mean/probability for the intervention
-group in the next stage )
+est_rec_int = recommended interventions,
+rec_int_cost = associated cost of the recommended interventions,
+est_reachable_outcome = estimated outcome mean/probability for the
+intervention group in the next stage,
+shrinking_method_used = whether the shrinking method was applied,
+effective_outcome_goal = the outcome goal actually used for optimization,
+i.e. max(power-implied outcome, outcome_goal) )
 }
 \description{
 Internal function that calculates the LAGO recommended

--- a/man/lago_optimization.Rd
+++ b/man/lago_optimization.Rd
@@ -12,8 +12,8 @@ lago_optimization(
   intervention_components,
   intervention_lower_bounds,
   intervention_upper_bounds,
-  outcome_goal,
-  outcome_goal_intention,
+  outcome_goal = NULL,
+  outcome_goal_intention = "maximize",
   power_goal = NULL,
   power_goal_approach = "unconditional",
   num_centers_in_next_stage = NULL,
@@ -73,15 +73,30 @@ For example: for a two-component intervention package, upper bounds could be
 c(10,20).}
 
 \item{outcome_goal}{A numeric value. Specifies the outcome goal, a desired
-probability or mean value.}
+probability or mean value.
+Default value without user specification: NULL.
+At least one of outcome_goal or power_goal must be provided. If only a
+power goal is provided, the optimization target is the outcome level needed
+to achieve the power goal. If both are provided, the effective outcome goal
+is the higher of the two (see power_goal).}
 
 \item{outcome_goal_intention}{A character string. Specifies the intention of
 the outcome goal. Must be either "maximize" or "minimize". If the goal is to
 increase the outcome, set it to "maximize". If the goal is to decrease the
-outcome, set it to "minimize".}
+outcome, set it to "minimize".
+Default value without user specification: "maximize".
+Note: "minimize" cannot be combined with a power goal, because achieving a
+power goal requires increasing the outcome.}
 
 \item{power_goal}{A numeric value. Specifies the power goal, a desired power
-value.
+value (between 0 and 1). Only supported for binary outcomes, and requires a
+'group' column (values "treatment"/"control") along with
+num_centers_in_next_stage and patients_per_center_in_next_stage.
+At least one of outcome_goal or power_goal must be provided. The power goal
+is converted into the outcome level needed to achieve that power; the
+effective outcome goal used for optimization is
+max(power-implied outcome, outcome_goal). When only a power goal is
+provided, the power-implied outcome is used directly.
 Default value without user specification: NULL.}
 
 \item{power_goal_approach}{A character string. Specifies the approach to

--- a/tests/manual_tests/test_goal_modes.Rmd
+++ b/tests/manual_tests/test_goal_modes.Rmd
@@ -1,0 +1,186 @@
+---
+title: "Manually test the three goal modes: outcome goal alone, power goal alone, and both together."
+output: pdf_document
+date: "`r Sys.Date()`"
+author: "Ante Bing"
+editor_options:
+  chunk_output_type: console
+---
+## We manually test that LAGO optimization supports three goal modes:
+## 1. an outcome goal alone,
+## 2. a power goal alone, and
+## 3. an outcome goal and a power goal together.
+## When both are provided, the effective outcome goal is the higher of the
+## outcome goal and the power-implied outcome (the "whichever is higher" rule).
+
+```{r}
+devtools::clean_dll()
+devtools::load_all()
+```
+
+```{r}
+# BetterBirth data, with a 'group' column so that a power goal can be used.
+bb_data <- LAGO::BB_data
+bb_data$group <- ifelse(bb_data$pre_post == 0, "control", "treatment")
+head(bb_data)
+```
+
+## Mode 1: outcome goal alone (no power goal)
+```{r}
+# This is the classic LAGO usage and should reproduce the Nevo et al. result
+# (launch duration ~2.78 days and 1 coaching visit).
+res_outcome_only <- lago_optimization(
+  data = bb_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  outcome_goal = 0.85,
+  outcome_goal_intention = "maximize",
+  include_confidence_set = FALSE
+)
+res_outcome_only$rec_int
+# expected: coaching_updt = 1, launch_duration ~ 2.78
+```
+
+## Mode 2: power goal alone (no outcome goal)
+```{r}
+# No outcome_goal is supplied. The optimization target is entirely determined
+# by the power goal (the outcome level needed to achieve the desired power).
+# num_centers_in_next_stage and patients_per_center_in_next_stage are required
+# for the power calculation.
+res_power_only <- lago_optimization(
+  data = bb_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  power_goal = 0.8,
+  num_centers_in_next_stage = 10,
+  patients_per_center_in_next_stage = 30,
+  include_confidence_set = FALSE
+)
+res_power_only$rec_int
+res_power_only$est_outcome_goal
+# the target here is the power-implied outcome, not a user outcome goal.
+```
+
+```{r}
+# power goal alone, conditional power approach.
+# The conditional approach produces a power-implied outcome that varies more
+# visibly with the power goal.
+res_power_only_cond <- lago_optimization(
+  data = bb_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  power_goal = 0.8,
+  power_goal_approach = "conditional",
+  num_centers_in_next_stage = 10,
+  patients_per_center_in_next_stage = 30,
+  include_confidence_set = FALSE
+)
+res_power_only_cond$rec_int
+```
+
+## Mode 3: outcome goal and power goal together
+```{r}
+# When both are provided, the effective outcome goal is
+# max(power-implied outcome, outcome_goal). Here outcome_goal = 0.85 exceeds
+# the power-implied outcome, so the result matches Mode 1 (the outcome goal
+# binds).
+res_both <- lago_optimization(
+  data = bb_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  outcome_goal = 0.85,
+  outcome_goal_intention = "maximize",
+  power_goal = 0.8,
+  num_centers_in_next_stage = 10,
+  patients_per_center_in_next_stage = 30,
+  include_confidence_set = FALSE
+)
+res_both$rec_int
+# expected: same as Mode 1, because the outcome goal (0.85) is higher than
+# the power-implied outcome.
+```
+
+## Failed cases
+```{r}
+# neither an outcome goal nor a power goal is provided -> error
+res_neither <- lago_optimization(
+  data = bb_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8))
+)
+```
+
+```{r}
+# a power goal combined with outcome_goal_intention = "minimize" -> error,
+# because achieving a power goal requires increasing the outcome.
+res_power_minimize <- lago_optimization(
+  data = bb_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  outcome_goal = 0.85,
+  outcome_goal_intention = "minimize",
+  power_goal = 0.8,
+  num_centers_in_next_stage = 10,
+  patients_per_center_in_next_stage = 30
+)
+```
+
+## Confidence set with a power goal alone
+```{r}
+# the confidence set calculation also works when only a power goal is given;
+# it uses the power-implied outcome as the goal. When no intervention
+# package's confidence interval covers the goal, an empty confidence set is
+# reported gracefully (confidence_set_size_percentage = 0) instead of erroring.
+res_power_cs <- lago_optimization(
+  data = bb_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  power_goal = 0.8,
+  num_centers_in_next_stage = 10,
+  patients_per_center_in_next_stage = 30,
+  confidence_set_grid_step_size = c(1, 0.5)
+)
+res_power_cs$confidence_set_size_percentage
+```

--- a/tests/manual_tests/test_goal_modes.Rmd
+++ b/tests/manual_tests/test_goal_modes.Rmd
@@ -124,6 +124,38 @@ res_both$rec_int
 # the power-implied outcome.
 ```
 
+## Regression check: outcome goal with "minimize" and a confidence set
+```{r}
+# This exercises the minimize + confidence set path. The optimization
+# internally negates the model coefficients and the goal, but the confidence
+# set is computed on the original (un-negated) model, so it must receive the
+# outcome goal on the original scale. A non-empty confidence set here confirms
+# the effective goal is not accidentally passed to the confidence set on the
+# negated scale.
+res_minimize_cs <- lago_optimization(
+  data = mtcars,
+  input_data_structure = "individual_level",
+  outcome_name = "mpg",
+  outcome_type = "continuous",
+  glm_family = "gaussian",
+  link = "identity",
+  intervention_components = c("disp", "hp"),
+  intervention_lower_bounds = c(0, 0),
+  intervention_upper_bounds = c(500, 350),
+  cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+  outcome_goal = 10,
+  outcome_goal_intention = "minimize",
+  confidence_set_grid_step_size = c(10, 10),
+  optimization_method = "grid_search",
+  optimization_grid_search_step_size = c(10, 10),
+  include_confidence_set = TRUE
+)
+res_minimize_cs$rec_int
+res_minimize_cs$confidence_set_size_percentage
+# expected: a non-empty confidence set (percentage > 0), matching the behavior
+# before the goal-modes change (about 0.184).
+```
+
 ## Failed cases
 ```{r}
 # neither an outcome goal nor a power goal is provided -> error

--- a/tests/manual_tests/test_goal_modes.Rmd
+++ b/tests/manual_tests/test_goal_modes.Rmd
@@ -96,7 +96,7 @@ res_power_only_cond <- lago_optimization(
 res_power_only_cond$rec_int
 ```
 
-## Mode 3: outcome goal and power goal together
+## Mode 3a: both goals, the outcome goal is higher (outcome goal binds)
 ```{r}
 # When both are provided, the effective outcome goal is
 # max(power-implied outcome, outcome_goal). Here outcome_goal = 0.85 exceeds
@@ -122,6 +122,46 @@ res_both <- lago_optimization(
 res_both$rec_int
 # expected: same as Mode 1, because the outcome goal (0.85) is higher than
 # the power-implied outcome.
+```
+
+## Mode 3b: both goals, the power goal is higher (power goal binds), with a confidence set
+```{r}
+# Here the power-implied outcome exceeds the user's outcome goal, so the
+# effective goal is the power-implied outcome. The confidence set is built
+# around that same effective goal, so the recommended intervention (whose
+# estimated outcome equals the effective goal) stays consistent with the
+# confidence set and the reported estimated outcome goal.
+set.seed(7)
+n <- 400
+synth <- data.frame(
+  x1 = runif(n, 0, 20),
+  x2 = runif(n, 0, 10),
+  group = rep(c("control", "treatment"), each = n / 2)
+)
+lp <- -1 + 0.15 * synth$x1 + 0.25 * synth$x2 + 0.4 * (synth$group == "treatment")
+synth$outcome <- rbinom(n, 1, 1 / (1 + exp(-lp)))
+
+res_both_power_binds <- lago_optimization(
+  data = synth,
+  outcome_name = "outcome",
+  outcome_type = "binary",
+  intervention_components = c("x1", "x2"),
+  intervention_lower_bounds = c(0, 0),
+  intervention_upper_bounds = c(20, 10),
+  cost_list_of_vectors = list(c(0, 4), c(0, 1)),
+  outcome_goal = 0.68,
+  outcome_goal_intention = "maximize",
+  power_goal = 0.8,
+  num_centers_in_next_stage = 10,
+  patients_per_center_in_next_stage = 30,
+  confidence_set_grid_step_size = c(1, 0.5)
+)
+res_both_power_binds$rec_int
+res_both_power_binds$est_outcome_goal
+res_both_power_binds$confidence_set_size_percentage
+# expected: est_outcome_goal is the power-implied outcome (~0.825, above the
+# outcome goal of 0.68), and a non-empty confidence set built around that
+# effective goal (percentage ~0.27).
 ```
 
 ## Regression check: outcome goal with "minimize" and a confidence set


### PR DESCRIPTION
Previously outcome_goal was required, so power_goal could never be used alone. Now, at least one of the goals is required, enabling 3 modes: outcome goal alone, power goal alone, or both. 

also fixes a pre-existing crash when the confidence set is empty, and bumps the version to 1.0.12

adds new manual test file: test_goal_modes.Rmd covering all three modes mentioned above. 