### PR TITLE
Clarify help for outcome_goal_intention and center_characteristics_op…

### DIFF
--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -41,7 +41,10 @@
 #' @param center_characteristics A character vector. The names of the columns in
 #' the dataset that represent the center characteristics.
 #' @param center_characteristics_optimization_values A numeric vector. The
-#' values of the center characteristics that will be used for LAGO optimization.
+#' fixed values of the center characteristics at which the confidence set is
+#' computed, so the confidence set is specific to a center with these
+#' characteristic values. Must have the same length and order as
+#' center_characteristics.
 #' @param confidence_set_alpha A numeric value. The type I error considered in
 #' the confidence set calculations.
 #' @param cluster_id A list or NULL. Specifies the columns of data that will be

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -23,8 +23,11 @@
 #' the center characteristics.
 #' For example: c(-0.4).
 #' @param center_characteristics_optimization_values A numeric vector. The
-#' values of the center characteristics that will be used for LAGO optimization.
-#' For example: c(1.74)
+#' fixed values of the center characteristics at which the recommended
+#' intervention is computed, so the recommendation is specific to a center with
+#' these characteristic values. Must have the same length and order as
+#' center_characteristics.
+#' For example: c(1.75)
 #' @param cost_list_of_vectors A list of numeric vectors. Specifies the cost
 #' functions for each intervention component. Each numeric vector in the list
 #' contains coefficients of the cost function for one intervention component.

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -29,10 +29,17 @@
 #' power goal is provided, the optimization target is the outcome level needed
 #' to achieve the power goal. If both are provided, the effective outcome goal
 #' is the higher of the two (see power_goal).
-#' @param outcome_goal_intention A character string. Specifies the intention of
-#' the outcome goal. Must be either "maximize" or "minimize". If the goal is to
-#' increase the outcome, set it to "maximize". If the goal is to decrease the
-#' outcome, set it to "minimize".
+#' @param outcome_goal_intention A character string. Specifies the direction in
+#' which the interventions are expected to move the outcome, relative to the
+#' outcome without any intervention. Must be either "maximize" or "minimize".
+#' Set it to "maximize" when a larger outcome is desired and the interventions
+#' are meant to increase the outcome up to the outcome goal (for example,
+#' increasing the probability that a treatment is administered). Set it to
+#' "minimize" when a smaller outcome is desired and the interventions are meant
+#' to decrease the outcome down to the outcome goal (for example, reducing a
+#' mortality rate). This argument only controls the optimization direction; the
+#' outcome goal itself is always given as the target outcome value, regardless
+#' of the intention.
 #' Default value without user specification: "maximize".
 #' Note: "minimize" cannot be combined with a power goal, because achieving a
 #' power goal requires increasing the outcome.
@@ -75,8 +82,16 @@
 #' together at the same time.
 #' For example: c("characteristic1")
 #' @param center_characteristics_optimization_values A numeric vector. The
-#' values of the center characteristics that will be used for LAGO optimization.
-#' For example: c(1.74)
+#' fixed values of the center characteristics at which the recommended
+#' intervention is computed. Because the outcome model can depend on center
+#' characteristics, the recommendation is specific to a center with these
+#' characteristic values, i.e. the optimization answers "what is the optimal
+#' intervention for a center whose characteristics equal these values?". Must
+#' be provided when center_characteristics is used, must be numeric, and must
+#' have the same length and order as center_characteristics.
+#' For example, with center_characteristics = c("birth_volume_100"), setting
+#' center_characteristics_optimization_values = c(1.75) computes the
+#' recommended intervention for a center with birth_volume_100 = 1.75.
 #' @param include_center_effects A boolean. Specifies whether the fixed effects
 #' should be included in the outcome model. If set to TRUE, please make sure
 #' that the input data has a 'center' column to identify the centers.

--- a/man/get_confidence_set.Rd
+++ b/man/get_confidence_set.Rd
@@ -85,7 +85,10 @@ size of the grid search algorithm used in the confidence set calculation.}
 the dataset that represent the center characteristics.}
 
 \item{center_characteristics_optimization_values}{A numeric vector. The
-values of the center characteristics that will be used for LAGO optimization.}
+fixed values of the center characteristics at which the confidence set is
+computed, so the confidence set is specific to a center with these
+characteristic values. Must have the same length and order as
+center_characteristics.}
 
 \item{confidence_set_alpha}{A numeric value. The type I error considered in
 the confidence set calculations.}

--- a/man/get_recommended_interventions.Rd
+++ b/man/get_recommended_interventions.Rd
@@ -99,8 +99,11 @@ the center characteristics.
 For example: c(-0.4).}
 
 \item{center_characteristics_optimization_values}{A numeric vector. The
-values of the center characteristics that will be used for LAGO optimization.
-For example: c(1.74)}
+fixed values of the center characteristics at which the recommended
+intervention is computed, so the recommendation is specific to a center with
+these characteristic values. Must have the same length and order as
+center_characteristics.
+For example: c(1.75)}
 
 \item{link}{A character string. Specifies the link function used when fitting
 the outcome model.}

--- a/man/lago_optimization.Rd
+++ b/man/lago_optimization.Rd
@@ -80,10 +80,17 @@ power goal is provided, the optimization target is the outcome level needed
 to achieve the power goal. If both are provided, the effective outcome goal
 is the higher of the two (see power_goal).}
 
-\item{outcome_goal_intention}{A character string. Specifies the intention of
-the outcome goal. Must be either "maximize" or "minimize". If the goal is to
-increase the outcome, set it to "maximize". If the goal is to decrease the
-outcome, set it to "minimize".
+\item{outcome_goal_intention}{A character string. Specifies the direction in
+which the interventions are expected to move the outcome, relative to the
+outcome without any intervention. Must be either "maximize" or "minimize".
+Set it to "maximize" when a larger outcome is desired and the interventions
+are meant to increase the outcome up to the outcome goal (for example,
+increasing the probability that a treatment is administered). Set it to
+"minimize" when a smaller outcome is desired and the interventions are meant
+to decrease the outcome down to the outcome goal (for example, reducing a
+mortality rate). This argument only controls the optimization direction; the
+outcome goal itself is always given as the target outcome value, regardless
+of the intention.
 Default value without user specification: "maximize".
 Note: "minimize" cannot be combined with a power goal, because achieving a
 power goal requires increasing the outcome.}
@@ -165,8 +172,16 @@ together at the same time.
 For example: c("characteristic1")}
 
 \item{center_characteristics_optimization_values}{A numeric vector. The
-values of the center characteristics that will be used for LAGO optimization.
-For example: c(1.74)}
+fixed values of the center characteristics at which the recommended
+intervention is computed. Because the outcome model can depend on center
+characteristics, the recommendation is specific to a center with these
+characteristic values, i.e. the optimization answers "what is the optimal
+intervention for a center whose characteristics equal these values?". Must
+be provided when center_characteristics is used, must be numeric, and must
+have the same length and order as center_characteristics.
+For example, with center_characteristics = c("birth_volume_100"), setting
+center_characteristics_optimization_values = c(1.75) computes the
+recommended intervention for a center with birth_volume_100 = 1.75.}
 
 \item{main_components}{A character vector. Specifies the main intervention
 components in the presence of interaction terms.


### PR DESCRIPTION
Issue #38: the help-file descriptions for these two arguments were unclear.

- outcome_goal_intention: explain that it sets the DIRECTION the interventions move the outcome (relative to no intervention), with concrete examples for "maximize"/"minimize", and clarify that it only controls the optimization direction while the outcome goal is always given as the target outcome value.
- center_characteristics_optimization_values: explain these are the fixed values the center characteristics are held at when computing the recommendation, so the recommendation is specific to a center with those values; document that they must be numeric and match center_characteristics in length and order. Also fixes the example (c(1.74) -> c(1.75)) to match the runnable @examples.

Also aligns the same center_characteristics_optimization_values description in the internal functions get_recommended_interventions() and get_confidence_set() so the help is consistent across the package (the get_confidence_set wording refers to the confidence set computation specifically).

Documentation only; man/*.Rd regenerated with roxygen2. Reviewed for factual accuracy against the code.