### PR TITLE
Switch to grid_search when a grid step size is provided (#32)

### DIFF
--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -139,8 +139,13 @@
 #' intervention package compositions in LAGO optimization.
 #' - Use "numerical" if you want to use gradient-based technique in LAGO
 #' optimization.
+#' Note: if optimization_grid_search_step_size is provided while this is
+#' "numerical", it is automatically switched to "grid_search" (with a message).
 #' @param optimization_grid_search_step_size A numeric vector. Specifies the
-#' step size of the grid search algorithm used in LAGO optimization.
+#' step size of the grid search algorithm used in LAGO optimization. This
+#' argument is only used by the "grid_search" method; if it is provided while
+#' optimization_method is "numerical", optimization_method is automatically
+#' switched to "grid_search" (with a message).
 #' Default value without user specification:
 #' 1/20 of the range for each intervention component.
 #' @param include_confidence_set A boolean. Specifies whether the confidence set

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -669,27 +669,15 @@ validate_inputs <- function(
     ))
   }
 
-  # when the optimization_method is grid_search,
-  # check the number of intervention components
-  if (optimization_method == "grid_search") {
-    if (length(intervention_components) > 3) {
-      message(paste0(
-        "There are more than 3 intervention components, and the grid search ",
-        "algorithm may take significant amount of time to run. ",
-        "Please consider adjusting the step size, or switch to the ",
-        "numerical optimization method."
-      ))
-    }
-  }
-
-  # if optimization_grid_search_step_size is provided,
-  # it needs to be a numeric vector
+  # if optimization_grid_search_step_size is provided, validate it before it
+  # can influence optimization_method below, so that an invalid step size is
+  # rejected up front rather than after a "switched to grid_search" message.
   if (!is.null(optimization_grid_search_step_size)) {
+    # it needs to be a numeric vector
     if (!(is.vector(optimization_grid_search_step_size) &&
       is.numeric(optimization_grid_search_step_size))) {
       stop("optimization_grid_search_step_size must be a numeric vector.")
     }
-    # if optimization_grid_search_step_size is provided,
     # it needs to have the same length as the number of intervention components
     if ((!include_interaction_terms &&
       (length(optimization_grid_search_step_size) !=
@@ -707,6 +695,43 @@ validate_inputs <- function(
         "With interaciton terms,",
         "The number of step sizes provided for the grid search",
         "algorithm must be the same as the length of 'main_components'."
+      ))
+    }
+    # each step size must be finite and strictly positive, otherwise the grid
+    # search seq() call would error or produce a degenerate grid.
+    if (!all(is.finite(optimization_grid_search_step_size)) ||
+      any(optimization_grid_search_step_size <= 0)) {
+      stop(paste(
+        "All elements of 'optimization_grid_search_step_size' must be",
+        "finite and greater than 0."
+      ))
+    }
+  }
+
+  # optimization_grid_search_step_size is only used by the grid search
+  # method. If it is provided while the method is "numerical", the user
+  # clearly intends to use grid search, so switch the method (with a
+  # message) instead of silently ignoring the step size.
+  if (!is.null(optimization_grid_search_step_size) &&
+    optimization_method == "numerical") {
+    optimization_method <- "grid_search"
+    message(paste(
+      "'optimization_grid_search_step_size' was provided, so",
+      "'optimization_method' has been switched to 'grid_search'.",
+      "To use the numerical method instead, remove",
+      "'optimization_grid_search_step_size'."
+    ))
+  }
+
+  # when the optimization_method is grid_search,
+  # check the number of intervention components
+  if (optimization_method == "grid_search") {
+    if (length(intervention_components) > 3) {
+      message(paste0(
+        "There are more than 3 intervention components, and the grid search ",
+        "algorithm may take significant amount of time to run. ",
+        "Please consider adjusting the step size, or switch to the ",
+        "numerical optimization method."
       ))
     }
   }

--- a/man/lago_optimization.Rd
+++ b/man/lago_optimization.Rd
@@ -156,7 +156,9 @@ Default value without user specification: "numerical".
 - Use "grid_search" if you want to exhaustively test every possible
 intervention package compositions in LAGO optimization.
 - Use "numerical" if you want to use gradient-based technique in LAGO
-optimization.}
+optimization.
+Note: if optimization_grid_search_step_size is provided while this is
+"numerical", it is automatically switched to "grid_search" (with a message).}
 
 \item{confidence_set_alpha}{A numeric value. The type I error considered in
 the confidence set calculations.
@@ -206,7 +208,10 @@ samples across all facilities - this percentage serves as that
 center's weight.}
 
 \item{optimization_grid_search_step_size}{A numeric vector. Specifies the
-step size of the grid search algorithm used in LAGO optimization.
+step size of the grid search algorithm used in LAGO optimization. This
+argument is only used by the "grid_search" method; if it is provided while
+optimization_method is "numerical", optimization_method is automatically
+switched to "grid_search" (with a message).
 Default value without user specification:
 1/20 of the range for each intervention component.}
 

--- a/tests/manual_tests/test_rec_int_for_cts_identity.Rmd
+++ b/tests/manual_tests/test_rec_int_for_cts_identity.Rmd
@@ -458,3 +458,31 @@ results <- lago_optimization(
   confidence_set_grid_step_size = c(1, 1)
 )
 ```
+
+## step size provided without grid_search method (issue #32)
+```{r}
+# optimization_grid_search_step_size is provided but optimization_method is
+# left at its default "numerical". The method should be automatically
+# switched to "grid_search" (with a message), instead of silently ignoring
+# the step size. The recommended interventions should land on the step-size
+# grid (integers here), not at a fractional numerical solution.
+results <- lago_optimization(
+  data = mtcars,
+  input_data_structure = "individual_level",
+  outcome_name = "mpg",
+  outcome_type = "continuous",
+  glm_family = "gaussian",
+  link = "identity",
+  intervention_components = c("gear", "qsec"),
+  intervention_lower_bounds = c(0, 0),
+  intervention_upper_bounds = c(10, 350),
+  cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+  outcome_goal = 40,
+  outcome_goal_intention = "maximize",
+  optimization_grid_search_step_size = c(1, 1),
+  include_confidence_set = FALSE
+)
+results$rec_int
+# expected: message about switching to grid_search, and integer rec_int
+# values (e.g. c(10, 12)), matching an explicit grid_search run.
+```


### PR DESCRIPTION
Previously, providing optimization_grid_search_step_size while optimization_method was "numerical" (the default) silently ignored the step size and ran the numerical method. Since the step size is only meaningful for grid search, validate_inputs() now switches optimization_method to "grid_search" and emits a message explaining the switch.

The switch also applies when optimization_method = "numerical" is passed explicitly. validate_inputs() cannot tell an explicit "numerical" from the default (it receives all arguments as supplied via do.call), so we chose to switch in both cases; the message tells the user how to get the numerical method back by removing the step size.

Hardening (from review):
- optimization_grid_search_step_size is now validated (numeric, correct length, and finite + strictly positive) BEFORE the method switch, so an invalid step size errors up front instead of after a misleading "switched to grid_search" message. This also closes a pre-existing gap where a zero, negative, or NA step size reached seq()/expand.grid with a cryptic error.

Docs updated (roxygen on both optimization_method and optimization_grid_search_step_size + .Rd regenerated); manual test chunk added to test_rec_int_for_cts_identity.Rmd.

Verified under R 4.5.3: auto-switched run matches an explicit grid_search run (rec_int 10, 12 on the mtcars example) and emits the message; zero/negative/NA step sizes now error cleanly with no switch message; numerical baseline without a step size is unchanged (10, 11.9574); existing explicit grid_search callers are unaffected.