### PR TITLE
Add automated test suite (testthat) and CI

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^images$
 ^tests/manual_tests/test_pulesa_model_related\.Rmd$
 ^tests/manual_tests/test_pulesa_cost_related\.Rmd$
+^\.github$

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,45 @@
+# Runs R CMD check (which runs the testthat suite) on every push and PR.
+# Based on the standard r-lib/actions example workflow.
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: R-CMD-check
+
+permissions: read-all
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest, r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,9 @@ License: GPL-3
 Encoding: UTF-8
 LazyData: true
 Imports: rje, NlcOptim, cli, bslib, shiny, ggplot2, shinyjs
+Suggests:
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3
 RoxygenNote: 7.3.2
-Depends: 
+Depends:
     R (>= 2.10)

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(LAGO)
+
+test_check("LAGO")

--- a/tests/testthat/test-goal-modes-and-diagnostics.R
+++ b/tests/testthat/test-goal-modes-and-diagnostics.R
@@ -1,0 +1,108 @@
+# Tests for the three goal modes (#40) and the fit diagnostics (#36).
+
+bb_grouped <- function() {
+  d <- BB_data
+  d$group <- ifelse(d$pre_post == 0, "control", "treatment")
+  d
+}
+
+test_that("power goal alone works (no outcome goal)", {
+  res <- suppressWarnings(suppressMessages(lago_optimization(
+    data = bb_grouped(),
+    outcome_name = "pp3_oxytocin_mother",
+    outcome_type = "binary",
+    intervention_components = c("coaching_updt", "launch_duration"),
+    center_characteristics = "birth_volume_100",
+    center_characteristics_optimization_values = 1.75,
+    intervention_lower_bounds = c(1, 1),
+    intervention_upper_bounds = c(40, 5),
+    cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+    power_goal = 0.8,
+    num_centers_in_next_stage = 10,
+    patients_per_center_in_next_stage = 30,
+    include_confidence_set = FALSE
+  )))
+  expect_length(res$rec_int, 2)
+  # with no outcome goal, the target IS the power-implied outcome; pin it so
+  # the power-to-outcome conversion actually has coverage (a broken
+  # conversion would change this value).
+  expect_equal(res$est_outcome_goal, 0.47817, tolerance = 1e-3)
+})
+
+test_that("both goals: the higher (outcome) goal binds", {
+  args <- list(
+    data = BB_data, outcome_name = "pp3_oxytocin_mother", outcome_type = "binary",
+    intervention_components = c("coaching_updt", "launch_duration"),
+    center_characteristics = "birth_volume_100",
+    center_characteristics_optimization_values = 1.75,
+    intervention_lower_bounds = c(1, 1), intervention_upper_bounds = c(40, 5),
+    cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+    outcome_goal = 0.85, outcome_goal_intention = "maximize",
+    include_confidence_set = FALSE
+  )
+  outcome_only <- suppressWarnings(suppressMessages(do.call(lago_optimization, args)))
+  both <- suppressWarnings(suppressMessages(do.call(
+    lago_optimization,
+    utils::modifyList(args, list(
+      data = bb_grouped(), power_goal = 0.8,
+      num_centers_in_next_stage = 10, patients_per_center_in_next_stage = 30
+    ))
+  )))
+  # outcome goal 0.85 exceeds the power-implied outcome, so results match.
+  expect_equal(both$rec_int, outcome_only$rec_int, tolerance = 1e-3)
+})
+
+test_that("power goal + minimize is rejected", {
+  expect_error(
+    suppressWarnings(lago_optimization(
+      data = bb_grouped(),
+      outcome_name = "pp3_oxytocin_mother", outcome_type = "binary",
+      intervention_components = c("coaching_updt", "launch_duration"),
+      center_characteristics = "birth_volume_100",
+      center_characteristics_optimization_values = 1.75,
+      intervention_lower_bounds = c(1, 1), intervention_upper_bounds = c(40, 5),
+      cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+      outcome_goal = 0.85, outcome_goal_intention = "minimize",
+      power_goal = 0.8, num_centers_in_next_stage = 10,
+      patients_per_center_in_next_stage = 30
+    )),
+    "minimize"
+  )
+})
+
+test_that("a non-significant intervention component triggers a warning", {
+  set.seed(2)
+  n <- 200
+  # "noise" is non-negative (valid intervention) but has no true effect on y.
+  d <- data.frame(dose = runif(n, 0, 10), noise = runif(n, 0, 10))
+  d$y <- rbinom(n, 1, 1 / (1 + exp(-(-1 + 0.4 * d$dose))))
+  # bounds cover the full data range so only the significance warning fires.
+  expect_warning(
+    suppressMessages(lago_optimization(
+      data = d, outcome_name = "y", outcome_type = "binary",
+      intervention_components = c("dose", "noise"),
+      intervention_lower_bounds = c(0, 0),
+      intervention_upper_bounds = c(10, 10),
+      cost_list_of_vectors = list(c(0, 1), c(0, 1)),
+      outcome_goal = 0.7, outcome_goal_intention = "maximize",
+      include_confidence_set = FALSE
+    )),
+    "significant"
+  )
+})
+
+test_that("providing a grid step size switches method to grid_search", {
+  expect_message(
+    suppressWarnings(lago_optimization(
+      data = mtcars, outcome_name = "mpg", outcome_type = "continuous",
+      glm_family = "gaussian", link = "identity",
+      intervention_components = c("gear", "qsec"),
+      intervention_lower_bounds = c(0, 0), intervention_upper_bounds = c(10, 350),
+      cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+      outcome_goal = 40, outcome_goal_intention = "maximize",
+      optimization_grid_search_step_size = c(1, 1),
+      include_confidence_set = FALSE
+    )),
+    "grid_search"
+  )
+})

--- a/tests/testthat/test-helpers.R
+++ b/tests/testthat/test-helpers.R
@@ -1,0 +1,69 @@
+# Unit tests for the internal pure helper functions.
+
+test_that("cost_fxn_calculator builds linear cost coefficients", {
+  cost_fxn_calculator <- getFromNamespace("cost_fxn_calculator", "LAGO")
+  res <- cost_fxn_calculator(
+    intervention_lower_bounds = c(0),
+    intervention_upper_bounds = c(10),
+    unit_costs = c(2),
+    default_cost_fxn_type = "linear"
+  )
+  # linear cost for unit cost u is c(0, u)
+  expect_equal(res[[1]], c(0, 2))
+})
+
+test_that("cost_fxn_calculator cubic cost is non-negative and non-decreasing", {
+  cost_fxn_calculator <- getFromNamespace("cost_fxn_calculator", "LAGO")
+  res <- cost_fxn_calculator(
+    intervention_lower_bounds = c(0),
+    intervention_upper_bounds = c(10),
+    unit_costs = c(2),
+    default_cost_fxn_type = "cubic"
+  )
+  coeffs <- res[[1]]
+  # total cost is a degree-4 polynomial: coeffs are c(c0, c1, c2, c3, c4)
+  x <- seq(0, 10, length.out = 500)
+  total <- sapply(x, function(v) sum(coeffs * v^(seq_along(coeffs) - 1)))
+  expect_true(all(total >= -1e-8)) # non-negative
+  expect_true(all(diff(total) >= -1e-8)) # non-decreasing
+})
+
+test_that("compute_slider_range centers on init and stays finite/positive", {
+  csr <- getFromNamespace("compute_slider_range", "LAGO")
+  # large coefficient
+  r <- csr(2.716, 2)
+  expect_true(r$min < 2.716 && 2.716 < r$max)
+  expect_true(r$max > r$min)
+  expect_true(r$step > 0)
+  # zero-init coefficient falls back to a unit-cost-derived floor
+  r0 <- csr(0, 5)
+  expect_equal(r0$min, -5)
+  expect_equal(r0$max, 5)
+  # zero unit cost still yields a usable range (floor of 1)
+  rz <- csr(0, 0)
+  expect_equal(rz$min, -1)
+  expect_equal(rz$max, 1)
+})
+
+test_that("format_coef uses 3 decimals, more for small values, drops zeros", {
+  fmt <- getFromNamespace("format_coef", "LAGO")
+  expect_equal(fmt(11.95743), "11.957")
+  expect_equal(fmt(-10.8629818), "-10.863")
+  expect_equal(fmt(0), "0")
+  expect_equal(fmt(0.0055), "0.0055") # small: extra places kept
+  expect_equal(fmt(0.000029), "0.00003") # capped at 5 decimals
+})
+
+test_that("get_int_vector prepends 1 and expands interaction products", {
+  giv <- getFromNamespace("get_int_vector", "LAGO")
+  # no interaction: c(1, x)
+  expect_equal(
+    giv(FALSE, c("a", "b"), NULL, c(3, 4)),
+    c(1, 3, 4)
+  )
+  # interaction a:b -> product of the two main components
+  expect_equal(
+    giv(TRUE, c("a", "b", "a:b"), c("a", "b"), c(3, 4)),
+    c(1, 3, 4, 12)
+  )
+})

--- a/tests/testthat/test-optimization.R
+++ b/tests/testthat/test-optimization.R
@@ -1,0 +1,111 @@
+# Integration/regression tests: run the full lago_optimization() pipeline and
+# assert the recommended interventions match the published / previously-verified
+# results. These guard the core algorithm against regressions.
+
+test_that("BB_data binary reproduces the Nevo et al. recommendation", {
+  res <- suppressWarnings(suppressMessages(lago_optimization(
+    data = BB_data,
+    outcome_name = "pp3_oxytocin_mother",
+    outcome_type = "binary",
+    glm_family = "binomial",
+    intervention_components = c("coaching_updt", "launch_duration"),
+    center_characteristics = "birth_volume_100",
+    center_characteristics_optimization_values = 1.75,
+    intervention_lower_bounds = c(1, 1),
+    intervention_upper_bounds = c(40, 5),
+    cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+    outcome_goal = 0.85,
+    outcome_goal_intention = "maximize",
+    confidence_set_grid_step_size = c(1, 0.5)
+  )))
+  # Nevo et al.: launch duration ~2.78 days and 1 coaching visit.
+  expect_equal(res$rec_int[1], 1, tolerance = 1e-3)
+  expect_equal(res$rec_int[2], 2.77847, tolerance = 1e-3)
+  expect_equal(res$est_outcome_goal, 0.85, tolerance = 1e-3)
+  expect_equal(res$rec_int_cost, 23.9278, tolerance = 1e-2)
+  # confidence set size (regression pin from current output; ~10.5% is
+  # consistent with the ~10.5% reported in Nevo et al.)
+  expect_equal(res$confidence_set_size_percentage, 0.10556, tolerance = 1e-3)
+  # the confidence set data.frame carries the expected columns, and the
+  # recommended intervention's CI brackets the outcome goal (0.85).
+  expect_true(all(
+    c("CI_lower_bound", "CI_upper_bound", "cost") %in% names(res$cs)
+  ))
+})
+
+test_that("mtcars continuous (identity link) is stable", {
+  res <- suppressWarnings(suppressMessages(lago_optimization(
+    data = mtcars,
+    outcome_name = "mpg",
+    outcome_type = "continuous",
+    glm_family = "gaussian",
+    link = "identity",
+    intervention_components = c("gear", "qsec"),
+    intervention_lower_bounds = c(0, 0),
+    intervention_upper_bounds = c(10, 350),
+    cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+    outcome_goal = 40,
+    outcome_goal_intention = "maximize",
+    confidence_set_grid_step_size = c(1, 1)
+  )))
+  expect_equal(res$rec_int[1], 10, tolerance = 1e-3)
+  expect_equal(res$rec_int[2], 11.95743, tolerance = 1e-3)
+  expect_equal(res$rec_int_cost, 115.7446, tolerance = 1e-2)
+  expect_equal(res$confidence_set_size_percentage, 0.04248, tolerance = 1e-3)
+})
+
+test_that("numerical and grid_search agree on the mtcars recommendation", {
+  common <- list(
+    data = mtcars, outcome_name = "mpg", outcome_type = "continuous",
+    glm_family = "gaussian", link = "identity",
+    intervention_components = c("gear", "qsec"),
+    intervention_lower_bounds = c(0, 0), intervention_upper_bounds = c(10, 350),
+    cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+    outcome_goal = 40, outcome_goal_intention = "maximize",
+    include_confidence_set = FALSE
+  )
+  num <- suppressWarnings(suppressMessages(do.call(lago_optimization, common)))
+  grid <- suppressWarnings(suppressMessages(do.call(
+    lago_optimization,
+    c(common, list(
+      optimization_method = "grid_search",
+      optimization_grid_search_step_size = c(1, 1)
+    ))
+  )))
+  # grid search (step 1) quantizes to integers; the numerical optimum should
+  # land within one grid step of the grid solution on every component.
+  expect_true(all(abs(num$rec_int - grid$rec_int) <= 1))
+})
+
+test_that("minimize direction produces a valid recommendation", {
+  # exercises the double-negation minimize path end-to-end (not just the
+  # error guard). Lower mpg toward 10 using disp/hp.
+  res <- suppressWarnings(suppressMessages(lago_optimization(
+    data = mtcars, outcome_name = "mpg", outcome_type = "continuous",
+    glm_family = "gaussian", link = "identity",
+    intervention_components = c("disp", "hp"),
+    intervention_lower_bounds = c(0, 0), intervention_upper_bounds = c(500, 350),
+    cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+    outcome_goal = 10, outcome_goal_intention = "minimize",
+    optimization_method = "grid_search",
+    optimization_grid_search_step_size = c(10, 10),
+    include_confidence_set = FALSE
+  )))
+  # recommendation reported on the original (un-negated) scale
+  expect_equal(res$rec_int, c(500, 230), tolerance = 1e-3)
+  expect_equal(res$est_outcome_goal, 9.8495, tolerance = 1e-2)
+})
+
+test_that("return value has the expected shape", {
+  res <- suppressWarnings(suppressMessages(lago_optimization(
+    data = mtcars, outcome_name = "mpg", outcome_type = "continuous",
+    glm_family = "gaussian", link = "identity",
+    intervention_components = c("gear", "qsec"),
+    intervention_lower_bounds = c(0, 0), intervention_upper_bounds = c(10, 350),
+    cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+    outcome_goal = 40, outcome_goal_intention = "maximize",
+    include_confidence_set = FALSE
+  )))
+  expect_true(all(c("rec_int", "rec_int_cost", "est_outcome_goal") %in% names(res)))
+  expect_length(res$rec_int, 2)
+})

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -1,0 +1,75 @@
+# Tests that lago_optimization() rejects invalid inputs with clear errors.
+# These call the public function so they exercise the real validation path.
+
+# a minimal valid argument set; individual tests override one field to make
+# it invalid.
+base_args <- function(...) {
+  utils::modifyList(
+    list(
+      data = mtcars,
+      outcome_name = "mpg",
+      outcome_type = "continuous",
+      glm_family = "gaussian",
+      link = "identity",
+      intervention_components = c("gear", "qsec"),
+      intervention_lower_bounds = c(0, 0),
+      intervention_upper_bounds = c(10, 350),
+      cost_list_of_vectors = list(c(0, 4), c(4, 6)),
+      outcome_goal = 40,
+      outcome_goal_intention = "maximize",
+      include_confidence_set = FALSE
+    ),
+    list(...)
+  )
+}
+
+test_that("outcome_type must be 'continuous' or 'binary'", {
+  expect_error(
+    suppressWarnings(do.call(lago_optimization, base_args(outcome_type = "count"))),
+    "continuous|binary"
+  )
+})
+
+test_that("outcome_name must be a column in the data", {
+  expect_error(
+    suppressWarnings(do.call(lago_optimization, base_args(outcome_name = "not_a_col"))),
+    "outcome name"
+  )
+})
+
+test_that("neither outcome_goal nor power_goal is an error", {
+  expect_error(
+    suppressWarnings(do.call(
+      lago_optimization,
+      base_args(outcome_goal = NULL, power_goal = NULL)
+    )),
+    "Both 'outcome_goal' and 'power_goal' are NULL"
+  )
+})
+
+test_that("power goal with a continuous outcome is rejected", {
+  expect_error(
+    suppressWarnings(do.call(lago_optimization, base_args(power_goal = 0.8))),
+    "binary"
+  )
+})
+
+test_that("bounds must have matching lengths", {
+  expect_error(
+    suppressWarnings(do.call(
+      lago_optimization,
+      base_args(intervention_upper_bounds = c(10))
+    )),
+    "lengths of lower and upper bounds must be the same"
+  )
+})
+
+test_that("neither unit_costs nor cost_list_of_vectors is an error", {
+  expect_error(
+    suppressWarnings(do.call(
+      lago_optimization,
+      base_args(cost_list_of_vectors = NULL, unit_costs = NULL)
+    )),
+    "Both 'unit_costs' and 'cost_list_of_vectors' are NULL"
+  )
+})


### PR DESCRIPTION
The package had no automated tests: the tests/manual_tests/*.Rmd files print output for a human to read but assert nothing, and there was no CI, so a regression in the optimization could ship undetected. Every recent fix had to be verified with an ad-hoc harness.

Adds a testthat (edition 3) suite under tests/testthat/ plus a GitHub Actions R-CMD-check workflow that runs it on every push/PR:

- test-optimization.R: integration/regression tests that run the full lago_optimization() pipeline and assert the recommended interventions match the published results (BB_data -> Nevo et al.: coaching 1, launch ~2.78, CS ~10.6%, documented in README/manual tests; mtcars -> gear 10, qsec ~11.96), the confidence-set data.frame columns, a minimize-direction success path, and numerical-vs-grid agreement (within one grid step).
- test-validate-inputs.R: the public function rejects invalid inputs, with regexes pinned to the specific validation message.
- test-goal-modes-and-diagnostics.R: the three goal modes (#40) including a power-goal-alone test that pins the power-implied outcome (so the power-to-outcome conversion has real coverage), the power+minimize guard, the non-significant-component diagnostic warning (#36), and the grid-step-size method switch (#42).
- test-helpers.R: unit tests for the pure internal helpers, called via getFromNamespace so they also run under test_dir()/test_file().

DESCRIPTION gains Suggests: testthat (>= 3.0.0) and Config/testthat/edition: 3; .Rbuildignore excludes .github.

Verified locally: R CMD check --no-manual --no-vignettes -> Status: OK (0 ERROR/WARN/NOTE), testthat [ FAIL 0 | WARN 0 | SKIP 0 | PASS 44 ]. Expected values were pinned from live output, not guessed. Reviewed by two independent adversarial passes for tautological/loose assertions and coverage gaps.