### PR TITLE
Return the overall intervention test result (#49)

### DIFF
--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -196,7 +196,10 @@
 #' associated cost for the interventions,
 #' estimated outcome mean/probability for the intervention group,
 #' 95% confidence set percentage,
-#' 95% confidence set)
+#' 95% confidence set,
+#' overall intervention test results (test_results), a list with the test
+#' statistic and p-value; NULL unless a valid 'group' column is supplied.
+#' The confidence set fields are only present when include_confidence_set = TRUE.)
 #'
 #' @examples
 #' # Basic case showing how to carry out the optimization with
@@ -473,7 +476,9 @@ lago_optimization <- function(
       list(
         rec_int = rec_int,
         rec_int_cost = rec_int_cost,
-        est_outcome_goal = est_outcome_goal
+        est_outcome_goal = est_outcome_goal,
+        # test_results is NULL unless a valid 'group' column was supplied
+        test_results = test_results
       )
     } else {
       list(
@@ -482,7 +487,9 @@ lago_optimization <- function(
         est_outcome_goal = est_outcome_goal,
         confidence_set_size_percentage = cs$confidence_set_size_percentage,
         # cs$cs is NULL when no confidence set was found for the goal
-        cs = if (is.null(cs$cs)) NULL else cs$cs[-1, ]
+        cs = if (is.null(cs$cs)) NULL else cs$cs[-1, ],
+        # test_results is NULL unless a valid 'group' column was supplied
+        test_results = test_results
       )
     }
   )

--- a/man/lago_optimization.Rd
+++ b/man/lago_optimization.Rd
@@ -271,7 +271,10 @@ recommended interventions,
 associated cost for the interventions,
 estimated outcome mean/probability for the intervention group,
 95% confidence set percentage,
-95% confidence set)
+95% confidence set,
+overall intervention test results (test_results), a list with the test
+statistic and p-value; NULL unless a valid 'group' column is supplied.
+The confidence set fields are only present when include_confidence_set = TRUE.)
 }
 \description{
 Fitting the outcome model, calculates the recommended

--- a/tests/testthat/test-optimization.R
+++ b/tests/testthat/test-optimization.R
@@ -109,3 +109,41 @@ test_that("return value has the expected shape", {
   expect_true(all(c("rec_int", "rec_int_cost", "est_outcome_goal") %in% names(res)))
   expect_length(res$rec_int, 2)
 })
+
+test_that("the overall test result is returned (not just printed) when a group column is present", {
+  bb <- BB_data
+  bb$group <- ifelse(bb$pre_post == 0, "control", "treatment")
+  common <- list(
+    data = bb, outcome_name = "pp3_oxytocin_mother", outcome_type = "binary",
+    intervention_components = c("coaching_updt", "launch_duration"),
+    center_characteristics = "birth_volume_100",
+    center_characteristics_optimization_values = 1.75,
+    intervention_lower_bounds = c(1, 1), intervention_upper_bounds = c(40, 5),
+    cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+    outcome_goal = 0.85, outcome_goal_intention = "maximize"
+  )
+  # returned both when the confidence set is skipped ...
+  res_no_cs <- suppressWarnings(suppressMessages(do.call(
+    lago_optimization, c(common, list(include_confidence_set = FALSE))
+  )))
+  expect_false(is.null(res_no_cs$test_results))
+  expect_true(all(c("test_stat", "p_val") %in% names(res_no_cs$test_results)))
+
+  # ... and when it is computed.
+  res_cs <- suppressWarnings(suppressMessages(do.call(
+    lago_optimization,
+    c(common, list(
+      include_confidence_set = TRUE, confidence_set_grid_step_size = c(1, 0.5)
+    ))
+  )))
+  expect_false(is.null(res_cs$test_results))
+  expect_equal(res_cs$test_results$test_stat, res_no_cs$test_results$test_stat)
+
+  # NULL (not missing) when no valid group column is supplied.
+  common_no_group <- common
+  common_no_group$data <- BB_data # BB_data has no 'group' column
+  res_no_group <- suppressWarnings(suppressMessages(do.call(
+    lago_optimization, c(common_no_group, list(include_confidence_set = FALSE))
+  )))
+  expect_null(res_no_group$test_results)
+})


### PR DESCRIPTION
lago_optimization() computed the overall intervention test via test_processor() and printed it, but never included it in the returned list, so result$test_results was always NULL for callers.

Add test_results to the returned list in both the include_confidence_set TRUE and FALSE branches (NULL when no valid 'group' column is supplied), document it in @return, and add a regression test covering both branches and the no-group case.