### PR TITLE
Add ICC (design-effect) option to the power calculation (#29)

### DIFF
--- a/R/get_power_desired_outcome.R
+++ b/R/get_power_desired_outcome.R
@@ -5,7 +5,78 @@ get_power_desired_outcome <- function(
     power_goal_approach,
     num_centers_in_next_stage,
     patients_per_center_in_next_stage,
-    outcome_name) {
+    outcome_name,
+    icc = NULL,
+    power_goal_cluster_id = NULL) {
+  # ---------------------------------------------------------------------------
+  # Design effects (issue #29). When icc is NULL the design effects are all 1
+  # and every variance below reduces bit-for-bit to the independent-binomial
+  # p(1-p)/N form, preserving the pre-icc behavior.
+  #
+  # Each arm's variance uses stage-specific design effects:
+  #   DE1 = 1 + (m1 - 1) * icc   (stage-1 cluster size m1, size-biased mean)
+  #   DE2 = 1 + (n2j - 1) * icc  (planned next-stage cluster size n2j)
+  # applied per the LAGO power paper (arXiv 2509.11479):
+  #   - unconditional (Theorem 1, stage-1 random): both stages are clustered,
+  #     Var_a = p_a(1-p_a) * (DE1_a*n_a1 + DE2_a*n_a2) / N_a^2
+  #   - conditional (Theorem 2, stage-1 fixed): the stage-2 prediction variance
+  #     (sigma_hat_x_2) clusters stage-2 only, while the rejection-threshold
+  #     term uses the final pooled (both-stage) proportion SE.
+  # ---------------------------------------------------------------------------
+  n2j <- patients_per_center_in_next_stage
+
+  # icc may be a scalar (shared) or length-2 c(control, treatment).
+  if (is.null(icc)) {
+    icc_ctl <- 0
+    icc_int <- 0
+  } else if (length(icc) == 1) {
+    icc_ctl <- icc
+    icc_int <- icc
+  } else {
+    icc_ctl <- icc[1]
+    icc_int <- icc[2]
+  }
+
+  # Size-biased (variance-appropriate) mean stage-1 cluster size for one arm:
+  # m1 = sum(m_i^2) / sum(m_i). Returns NA for a degenerate single-center arm.
+  size_biased_cluster_size <- function(arm_data) {
+    if (is.null(power_goal_cluster_id)) {
+      return(NA_real_)
+    }
+    m <- as.numeric(table(arm_data[[power_goal_cluster_id]]))
+    m <- m[m > 0]
+    if (length(m) < 2) {
+      return(NA_real_)
+    }
+    sum(m^2) / sum(m)
+  }
+
+  ctl_stage1_all <- data[data$group == "control", ]
+  int_stage1_all <- data[data$group == "treatment", ]
+  m1_ctl <- size_biased_cluster_size(ctl_stage1_all)
+  m1_int <- size_biased_cluster_size(int_stage1_all)
+
+  # When a design effect is requested we need a stage-1 cluster size. This is a
+  # hard dependency for the unconditional path (stage-1 is random there) and for
+  # the conditional rejection threshold (both-stage pooled SE). Fail loudly
+  # rather than silently under-clustering stage-1.
+  needs_stage1_de <- !is.null(icc) && (icc_ctl > 0 || icc_int > 0)
+  if (needs_stage1_de && (is.na(m1_ctl) || is.na(m1_int))) {
+    stop(paste(
+      "A non-zero 'icc' requires a valid 'power_goal_cluster_id' column that",
+      "identifies stage-1 centers, with at least two centers per arm, so the",
+      "stage-1 design effect can be computed. Please provide it, or set",
+      "icc = NULL / icc = 0."
+    ))
+  }
+
+  # Design effects per arm. m1 is only used when a design effect is requested;
+  # guard the NA case (icc == 0 / NULL) so DE1 stays 1.
+  de1_ctl <- if (is.na(m1_ctl)) 1 else 1 + (m1_ctl - 1) * icc_ctl
+  de1_int <- if (is.na(m1_int)) 1 else 1 + (m1_int - 1) * icc_int
+  de2_ctl <- 1 + (n2j - 1) * icc_ctl
+  de2_int <- 1 + (n2j - 1) * icc_int
+
   ##################################
   ## unconditional power approach ##
   ##################################
@@ -51,9 +122,13 @@ get_power_desired_outcome <- function(
       S1_2 <- n1_2 * expit_part
       S0_2 <- n0_2 * rje::expit(beta0)
 
-      top <- (S1_1 + S1_2) / N1 - (S0_1 + S0_2) / N0
-      bottom_part1 <- ((S1_1 + S1_2) / N1) * (1 - ((S1_1 + S1_2) / N1)) / N1
-      bottom_part2 <- ((S0_1 + S0_2) / N0) * (1 - ((S0_1 + S0_2) / N0)) / N0
+      p1 <- (S1_1 + S1_2) / N1
+      p0 <- (S0_1 + S0_2) / N0
+      top <- p1 - p0
+      # both-stage clustered variance (unconditional, Theorem 1). At icc = 0
+      # DE1 = DE2 = 1 and each term collapses to p(1-p)/N.
+      bottom_part1 <- p1 * (1 - p1) * (de1_int * n1_1 + de2_int * n1_2) / N1^2
+      bottom_part2 <- p0 * (1 - p0) * (de1_ctl * n0_1 + de2_ctl * n0_2) / N0^2
 
       if (bottom_part1 + bottom_part2 < 0) {
         # there is no point taking the sqrt of a negative number
@@ -93,7 +168,20 @@ get_power_desired_outcome <- function(
       pos_diff_idx <- which(ncp_diffs >= 0)
 
       if (length(pos_diff_idx) == 0) {
-        message("No non-negative NCP differences found in grid search.")
+        # no grid point reaches the required ncp: the power goal is infeasible
+        # at these inputs. When a design effect is in force, say so explicitly
+        # rather than silently returning an unreachable outcome.
+        if (!is.null(icc)) {
+          warning(paste(
+            "The design effect implied by 'icc' makes the power goal",
+            "infeasible for the given next-stage size: no attainable outcome",
+            "reaches the required power. Returning an unreachable outcome",
+            "(1); consider a larger next-stage sample, a lower power goal, or",
+            "reviewing the icc."
+          ))
+        } else {
+          message("No non-negative NCP differences found in grid search.")
+        }
         return(1)
       }
 
@@ -152,12 +240,23 @@ get_power_desired_outcome <- function(
         S1_2 <- n1_2 * expit_part
         S0_2 <- n0_2 * expit(beta0)
 
-        sqrt_part1 <- (S1_1 + S1_2) / N1 * (1 - (S1_1 + S1_2) / N1) / N1
-        sqrt_part2 <- (S0_1 + S0_2) / N0 * (1 - (S0_1 + S0_2) / N0) / N0
+        p1 <- (S1_1 + S1_2) / N1
+        p0 <- (S0_1 + S0_2) / N0
+        # rejection-threshold SE: uses the final pooled proportion (eq 5), so
+        # both stages are clustered here (both-stage form). DE applied inside
+        # the sqrt.
+        sqrt_part1 <- p1 * (1 - p1) * (de1_int * n1_1 + de2_int * n1_2) / N1^2
+        sqrt_part2 <- p0 * (1 - p0) * (de1_ctl * n0_1 + de2_ctl * n0_2) / N0^2
         z_alpha_sqrt_multiply_part <- z_alpha_over_2 * sqrt(sqrt_part1 + sqrt_part2)
 
         mu_hat_x_2 <- n1_2 * expit_part / N1 - n0_2 * expit(beta0) / N0
-        sigma_hat_x_2 <- sqrt(n0_2 * expit(beta0) * (1 - expit(beta0)) / N0^2 + n1_2 * expit_part * (1 - expit_part) / N1^2)
+        # stage-2 prediction variance: stage-1 is conditioned on (fixed), so
+        # only the stage-2 increment is clustered here. DE2 applied inside the
+        # sqrt (guarding against a DE^2 error on this sd-form term).
+        sigma_hat_x_2 <- sqrt(
+          de2_ctl * n0_2 * expit(beta0) * (1 - expit(beta0)) / N0^2 +
+            de2_int * n1_2 * expit_part * (1 - expit_part) / N1^2
+        )
 
         equation_result <- z_alpha_sqrt_multiply_part - S1_1 / N1 + S0_1 / N0 - mu_hat_x_2 + minus_z_pi * sigma_hat_x_2
         return(equation_result)
@@ -174,6 +273,20 @@ get_power_desired_outcome <- function(
       if (length(all_possible_expit_part_values) > 0) {
         final_expit_value <- all_possible_expit_part_values[1]
       } else {
+        # no attainable outcome satisfies the conditional-power inequality: the
+        # goal is infeasible at these inputs. Pre-icc this returned 0 silently,
+        # which drops the power goal downstream via max(0, outcome_goal). When a
+        # design effect is in force, warn explicitly instead of failing quietly.
+        if (!is.null(icc)) {
+          warning(paste(
+            "The design effect implied by 'icc' makes the power goal",
+            "infeasible for the given next-stage size under the conditional",
+            "approach: no attainable outcome satisfies the required power.",
+            "Returning 0, which does not raise the outcome goal; consider a",
+            "larger next-stage sample, a lower power goal, or reviewing the",
+            "icc."
+          ))
+        }
         final_expit_value <- 0
       }
       return(final_expit_value)

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -80,6 +80,14 @@
 #' Specifies the number of patients per center in the next stage.
 #' @param outcome_name A character string. Specifies the name of the outcome
 #' variable in the dataset.
+#' @param icc A numeric value in [0, 1), or a length-2 numeric vector
+#' c(control, treatment). Intra-cluster correlation used to inflate the
+#' power-calculation variance by a design effect. NULL (default) reproduces the
+#' original independent-observation behavior. Passed through to
+#' get_power_desired_outcome.
+#' @param power_goal_cluster_id A character string. The name of a column in the
+#' data identifying the stage-1 centers, used to compute the stage-1 design
+#' effect when icc is non-zero. Default NULL.
 #'
 #' @return List(
 #' est_rec_int = recommended interventions,
@@ -119,7 +127,9 @@ get_recommended_interventions <- function(
     power_goal_approach,
     num_centers_in_next_stage,
     patients_per_center_in_next_stage,
-    outcome_name) {
+    outcome_name,
+    icc = NULL,
+    power_goal_cluster_id = NULL) {
   # check if power goal is null, if not, calculate the desired outcome
   # value needed to achieve the power goal
   if (!is.null(power_goal)) {
@@ -130,7 +140,9 @@ get_recommended_interventions <- function(
       power_goal_approach,
       num_centers_in_next_stage,
       patients_per_center_in_next_stage,
-      outcome_name
+      outcome_name,
+      icc = icc,
+      power_goal_cluster_id = power_goal_cluster_id
     )
 
     new_outcome_goal <- max(power_desired_outcome, outcome_goal)

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -190,6 +190,23 @@
 #' @param patients_per_center_in_next_stage A numeric value. Specifies
 #' the number of patients per center in the next stage of the trial.
 #' Default value without user specification: NULL.
+#' @param icc A numeric value in [0, 1), or a length-2 numeric vector
+#' c(control, treatment). Specifies the intra-cluster correlation used to
+#' inflate the variance of the power-calculation test statistic by a design
+#' effect, so that the power goal accounts for within-center clustering.
+#' Only used when a power_goal is provided (ignored otherwise). When NULL, the
+#' power calculation assumes independent observations (the original behavior);
+#' icc = 0 gives the identical result. A larger icc raises the outcome level
+#' needed to meet the power goal, so it recommends a stronger intervention. A
+#' non-zero icc requires power_goal_cluster_id.
+#' Default value without user specification: NULL.
+#' @param power_goal_cluster_id A character string. The name of a column in the
+#' data identifying the stage-1 centers (clusters), used to compute the stage-1
+#' design effect for the power calculation. Required when icc is non-zero. The
+#' stage-1 cluster size is the variance-appropriate (size-biased) mean
+#' sum(m_i^2) / sum(m_i) over that arm's centers, and each arm must have at
+#' least two centers.
+#' Default value without user specification: NULL.
 #'
 #' @return List(
 #' recommended interventions,
@@ -269,6 +286,8 @@ lago_optimization <- function(
     power_goal_approach = "unconditional",
     num_centers_in_next_stage = NULL,
     patients_per_center_in_next_stage = NULL,
+    icc = NULL,
+    power_goal_cluster_id = NULL,
     unit_costs = NULL,
     default_cost_fxn_type = "cubic",
     cost_list_of_vectors = NULL,
@@ -374,7 +393,9 @@ lago_optimization <- function(
     power_goal_approach = power_goal_approach,
     num_centers_in_next_stage = num_centers_in_next_stage,
     patients_per_center_in_next_stage = patients_per_center_in_next_stage,
-    outcome_name = outcome_name
+    outcome_name = outcome_name,
+    icc = icc,
+    power_goal_cluster_id = power_goal_cluster_id
   )
   Sys.sleep(0.25)
   cli::cli_alert_success("Done")

--- a/R/rec_int_processor.R
+++ b/R/rec_int_processor.R
@@ -24,7 +24,9 @@ rec_int_processor <- function(
     power_goal_approach,
     num_centers_in_next_stage,
     patients_per_center_in_next_stage,
-    outcome_name) {
+    outcome_name,
+    icc = NULL,
+    power_goal_cluster_id = NULL) {
   # get coefficients for the intervention components
   intervention_components_coeff <-
     model$coefficients[c("(Intercept)", intervention_components)]
@@ -115,7 +117,9 @@ rec_int_processor <- function(
     power_goal_approach = power_goal_approach,
     num_centers_in_next_stage = num_centers_in_next_stage,
     patients_per_center_in_next_stage = patients_per_center_in_next_stage,
-    outcome_name = outcome_name
+    outcome_name = outcome_name,
+    icc = icc,
+    power_goal_cluster_id = power_goal_cluster_id
   )
 
   list(

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -12,6 +12,8 @@ validate_inputs <- function(
     power_goal_approach,
     num_centers_in_next_stage = NULL,
     patients_per_center_in_next_stage = NULL,
+    icc = NULL,
+    power_goal_cluster_id = NULL,
     unit_costs = NULL,
     default_cost_fxn_type = "cubic",
     cost_list_of_vectors = NULL,
@@ -965,6 +967,58 @@ validate_inputs <- function(
         stop("patients_per_center_in_next_stage must be greater than 0.")
       }
     }
+    # icc (issue #29): optional intra-cluster correlation used to inflate the
+    # power-calculation variance by a design effect. Scalar (shared across arms)
+    # or length-2 c(control, treatment). Each value must be in [0, 1).
+    if (!is.null(icc)) {
+      if (!is.numeric(icc)) {
+        stop("icc must be a numeric value (or a length-2 numeric vector).")
+      }
+      if (length(icc) != 1 && length(icc) != 2) {
+        stop("icc must have length 1 (shared) or 2 (control, treatment).")
+      }
+      if (any(icc < 0) || any(icc >= 1)) {
+        stop("icc must be in [0, 1).")
+      }
+      # a non-zero icc needs a stage-1 cluster id to compute the stage-1 design
+      # effect; validate the column exists and is non-degenerate per arm.
+      if (any(icc > 0)) {
+        if (is.null(power_goal_cluster_id)) {
+          stop(paste(
+            "A non-zero 'icc' requires 'power_goal_cluster_id', the name of a",
+            "column identifying stage-1 centers, so the stage-1 design effect",
+            "can be computed."
+          ))
+        }
+        if (!is.character(power_goal_cluster_id) ||
+          length(power_goal_cluster_id) != 1) {
+          stop("power_goal_cluster_id must be a single column name.")
+        }
+        if (!power_goal_cluster_id %in% names(data)) {
+          stop(paste0(
+            "power_goal_cluster_id column '", power_goal_cluster_id,
+            "' was not found in the data."
+          ))
+        }
+        # need at least two centers per arm to identify between-cluster variance
+        for (grp in c("control", "treatment")) {
+          n_centers <- length(unique(
+            data[data$group == grp, power_goal_cluster_id, drop = TRUE]
+          ))
+          if (n_centers < 2) {
+            stop(paste0(
+              "The '", grp, "' arm has fewer than two distinct ",
+              "power_goal_cluster_id centers, so the stage-1 design effect is ",
+              "not identifiable. Provide data with at least two centers per ",
+              "arm, or set icc = NULL."
+            ))
+          }
+        }
+      }
+    }
+  } else if (!is.null(icc)) {
+    # icc only affects the power calculation; without a power goal it is a no-op.
+    message("icc is ignored because no power_goal was provided.")
   }
 
   # check if power_goal_approach is a character type

--- a/man/get_recommended_interventions.Rd
+++ b/man/get_recommended_interventions.Rd
@@ -28,7 +28,9 @@ get_recommended_interventions(
   power_goal_approach,
   num_centers_in_next_stage,
   patients_per_center_in_next_stage,
-  outcome_name
+  outcome_name,
+  icc = NULL,
+  power_goal_cluster_id = NULL
 )
 }
 \arguments{
@@ -132,6 +134,16 @@ Specifies the number of patients per center in the next stage.}
 
 \item{outcome_name}{A character string. Specifies the name of the outcome
 variable in the dataset.}
+
+\item{icc}{A numeric value in [0, 1), or a length-2 numeric vector
+c(control, treatment). Intra-cluster correlation used to inflate the
+power-calculation variance by a design effect. NULL (default) reproduces the
+original independent-observation behavior. Passed through to
+get_power_desired_outcome.}
+
+\item{power_goal_cluster_id}{A character string. The name of a column in the
+data identifying the stage-1 centers, used to compute the stage-1 design
+effect when icc is non-zero. Default NULL.}
 }
 \value{
 List(

--- a/man/lago_optimization.Rd
+++ b/man/lago_optimization.Rd
@@ -18,6 +18,8 @@ lago_optimization(
   power_goal_approach = "unconditional",
   num_centers_in_next_stage = NULL,
   patients_per_center_in_next_stage = NULL,
+  icc = NULL,
+  power_goal_cluster_id = NULL,
   unit_costs = NULL,
   default_cost_fxn_type = "cubic",
   cost_list_of_vectors = NULL,
@@ -116,6 +118,25 @@ Default value without user specification: NULL.}
 
 \item{patients_per_center_in_next_stage}{A numeric value. Specifies
 the number of patients per center in the next stage of the trial.
+Default value without user specification: NULL.}
+
+\item{icc}{A numeric value in [0, 1), or a length-2 numeric vector
+c(control, treatment). Specifies the intra-cluster correlation used to
+inflate the variance of the power-calculation test statistic by a design
+effect, so that the power goal accounts for within-center clustering.
+Only used when a power_goal is provided (ignored otherwise). When NULL, the
+power calculation assumes independent observations (the original behavior);
+icc = 0 gives the identical result. A larger icc raises the outcome level
+needed to meet the power goal, so it recommends a stronger intervention. A
+non-zero icc requires power_goal_cluster_id.
+Default value without user specification: NULL.}
+
+\item{power_goal_cluster_id}{A character string. The name of a column in the
+data identifying the stage-1 centers (clusters), used to compute the stage-1
+design effect for the power calculation. Required when icc is non-zero. The
+stage-1 cluster size is the variance-appropriate (size-biased) mean
+sum(m_i^2) / sum(m_i) over that arm's centers, and each arm must have at
+least two centers.
 Default value without user specification: NULL.}
 
 \item{unit_costs}{A numeric vector. Specifies the unit costs for each

--- a/tests/manual_tests/test_icc_power.Rmd
+++ b/tests/manual_tests/test_icc_power.Rmd
@@ -1,0 +1,188 @@
+---
+title: "ICC (design effect) in the power calculation"
+output: pdf_document
+date: "`r Sys.Date()`"
+author: "Ante Bing"
+editor_options:
+  chunk_output_type: console
+---
+
+```{r}
+devtools::clean_dll()
+devtools::load_all()
+```
+
+# Purpose
+
+The power calculation converts a power goal into the outcome level needed to
+achieve it. Before issue #29 it assumed independent observations. All LAGO
+trials are clustered (patients nested in centers), so ignoring clustering
+overstates power and returns a target that is too easy to reach.
+
+The new `icc` argument inflates the variance of the power-calculation test
+statistic by a design effect, following the LAGO power paper (arXiv 2509.11479):
+
+- unconditional approach (Theorem 1, stage-1 random): both stages are clustered.
+- conditional approach (Theorem 2, stage-1 fixed): the stage-2 prediction
+  variance clusters stage-2 only.
+
+`icc = NULL` (default) reproduces the original behavior exactly. This file shows
+the effect of `icc` and the backward-compatibility guarantee.
+
+# 1. Backward compatibility on the BB example
+
+On BB_data the control-rate floor binds before the non-centrality constraint, so
+`icc` does not change the recommended intervention here. What we verify is that
+turning `icc` on with value 0 leaves the result identical to `icc = NULL`.
+
+```{r}
+bb <- LAGO::BB_data
+bb$group <- ifelse(bb$pre_post == 0, "control", "treatment")
+
+common <- list(
+  data = bb,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  center_characteristics = "birth_volume_100",
+  center_characteristics_optimization_values = 1.75,
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  power_goal = 0.8,
+  num_centers_in_next_stage = 10,
+  patients_per_center_in_next_stage = 30,
+  include_confidence_set = FALSE
+)
+
+res_null <- do.call(lago_optimization, common)
+res_icc0 <- do.call(
+  lago_optimization,
+  c(common, list(icc = 0, power_goal_cluster_id = "site_name"))
+)
+
+cat(sprintf("icc = NULL: est_outcome_goal = %.6f\n", res_null$est_outcome_goal))
+cat(sprintf("icc = 0   : est_outcome_goal = %.6f\n", res_icc0$est_outcome_goal))
+cat(sprintf("identical: %s\n",
+            isTRUE(all.equal(res_null$est_outcome_goal, res_icc0$est_outcome_goal))))
+```
+
+# 2. The effect of ICC where the power constraint binds
+
+To see `icc` actually move the target, we use a small clustered dataset where the
+non-centrality constraint binds (rather than the control-rate floor). We call the
+internal `get_power_desired_outcome()` directly and report the power-implied
+outcome as `icc` increases.
+
+```{r}
+set.seed(1)
+J <- 8
+m <- 10
+small <- do.call(rbind, lapply(seq_len(J), function(j) {
+  grp <- if (j <= J / 2) "control" else "treatment"
+  rate <- if (grp == "treatment") 0.45 else 0.30
+  data.frame(center = paste0("c", j), group = grp,
+             y = rbinom(m, 1, rate))
+}))
+coeff <- c(
+  "(Intercept)" = stats::qlogis(mean(small$y[small$group == "control"])),
+  "dose" = 0.6
+)
+
+power_implied <- function(icc, approach) {
+  suppressWarnings(get_power_desired_outcome(
+    data = small, intervention_components_coeff = coeff,
+    power_goal = 0.8, power_goal_approach = approach,
+    num_centers_in_next_stage = 20, patients_per_center_in_next_stage = 20,
+    outcome_name = "y",
+    icc = icc,
+    power_goal_cluster_id = if (is.null(icc) || all(icc == 0)) NULL else "center"
+  ))
+}
+
+cat("Unconditional approach:\n")
+for (icc in list(NULL, 0, 0.005, 0.01, 0.02, 0.05)) {
+  lbl <- if (is.null(icc)) "NULL" else format(icc)
+  cat(sprintf("  icc = %-6s  required outcome = %.5f\n", lbl,
+              power_implied(icc, "unconditional")))
+}
+
+cat("Conditional approach:\n")
+for (icc in list(NULL, 0, 0.005, 0.01, 0.02)) {
+  lbl <- if (is.null(icc)) "NULL" else format(icc)
+  cat(sprintf("  icc = %-6s  required outcome = %.5f\n", lbl,
+              power_implied(icc, "conditional")))
+}
+```
+
+The required outcome rises with `icc`: honoring the within-center clustering
+means a stronger intervention is needed to still meet the same power goal. This
+is the correction the power calculation was missing.
+
+# 3. Per-arm ICC
+
+`icc` may be a length-2 vector `c(control, treatment)` when the two arms have
+different intra-cluster correlations.
+
+```{r}
+cat(sprintf("scalar icc = 0.01        : %.5f\n",
+            power_implied(0.01, "unconditional")))
+cat(sprintf("per-arm  icc = c(.01,.01): %.5f  (matches scalar)\n",
+            power_implied(c(0.01, 0.01), "unconditional")))
+cat(sprintf("per-arm  icc = c(.02,.005): %.5f\n",
+            power_implied(c(0.02, 0.005), "unconditional")))
+```
+
+# 4. Infeasible ICC warns, does not silently drop the power goal
+
+When the design effect is large enough that no attainable outcome meets the
+power goal, the function warns explicitly. Previously the conditional path
+returned 0 silently, which dropped the power goal via `max(0, outcome_goal)`.
+
+```{r}
+tryCatch(
+  withCallingHandlers(
+    get_power_desired_outcome(
+      data = small, intervention_components_coeff = coeff,
+      power_goal = 0.8, power_goal_approach = "unconditional",
+      num_centers_in_next_stage = 4, patients_per_center_in_next_stage = 8,
+      outcome_name = "y", icc = 0.3, power_goal_cluster_id = "center"
+    ),
+    warning = function(w) {
+      cat("WARNING RAISED:\n  ", conditionMessage(w), "\n")
+      invokeRestart("muffleWarning")
+    }
+  ),
+  error = function(e) cat("error:", conditionMessage(e), "\n")
+)
+```
+
+# 5. Validation
+
+```{r}
+show_error <- function(expr) {
+  tryCatch({
+    suppressWarnings(suppressMessages(expr))
+    cat("  (no error)\n")
+  }, error = function(e) cat("  error:", conditionMessage(e), "\n"))
+}
+
+small_dose <- transform(small, dose = ifelse(group == "treatment", 1, 0))
+base_small <- list(
+  data = small_dose, outcome_name = "y", outcome_type = "binary",
+  intervention_components = "dose",
+  intervention_lower_bounds = 0, intervention_upper_bounds = 1,
+  cost_list_of_vectors = list(c(0, 1)),
+  power_goal = 0.8, num_centers_in_next_stage = 4,
+  patients_per_center_in_next_stage = 8, include_confidence_set = FALSE
+)
+
+cat("icc out of range (1.2):\n")
+show_error(do.call(lago_optimization,
+                  c(base_small, list(icc = 1.2, power_goal_cluster_id = "center"))))
+cat("non-zero icc without power_goal_cluster_id:\n")
+show_error(do.call(lago_optimization, c(base_small, list(icc = 0.05))))
+cat("cluster id column not in data:\n")
+show_error(do.call(lago_optimization,
+                  c(base_small, list(icc = 0.05, power_goal_cluster_id = "nope"))))
+```

--- a/tests/testthat/test-icc-power.R
+++ b/tests/testthat/test-icc-power.R
@@ -1,0 +1,303 @@
+# Tests for the ICC / design-effect option in the power calculation (issue #29).
+#
+# The design effect only bites when the ncp constraint binds, which needs a
+# small sample (on large data the control-rate floor binds first and icc cannot
+# move the answer). We build a small clustered synthetic dataset for the
+# direct-function tests, and use BB_data for the backward-compat path.
+
+make_small_clustered <- function() {
+  # deterministic small two-arm clustered dataset. J centers per label, m each.
+  J <- 8
+  m <- 10
+  rows <- list()
+  # fixed 0/1 pattern per center to avoid any RNG dependence across R versions
+  for (j in seq_len(J)) {
+    grp <- if (j <= J / 2) "control" else "treatment"
+    rate <- if (grp == "treatment") 0.45 else 0.30
+    y <- as.integer(seq_len(m) / m <= rate)
+    rows[[j]] <- data.frame(
+      center = paste0("c", j), group = grp, y = y
+    )
+  }
+  do.call(rbind, rows)
+}
+
+small_coeff <- function(d) {
+  c(
+    "(Intercept)" = stats::qlogis(mean(d$y[d$group == "control"])),
+    "dose" = 0.6
+  )
+}
+
+test_that("icc = NULL and icc = 0 give identical power-implied outcomes", {
+  d <- make_small_clustered()
+  coeff <- small_coeff(d)
+  common <- list(
+    data = d, intervention_components_coeff = coeff, power_goal = 0.8,
+    power_goal_approach = "unconditional", num_centers_in_next_stage = 20,
+    patients_per_center_in_next_stage = 20, outcome_name = "y"
+  )
+  null_res <- suppressWarnings(do.call(get_power_desired_outcome, common))
+  zero_res <- suppressWarnings(do.call(
+    get_power_desired_outcome,
+    c(common, list(icc = 0, power_goal_cluster_id = "center"))
+  ))
+  expect_equal(null_res, zero_res)
+})
+
+test_that("a larger icc raises the power-implied outcome (both approaches)", {
+  d <- make_small_clustered()
+  coeff <- small_coeff(d)
+  call_icc <- function(icc, approach) {
+    suppressWarnings(get_power_desired_outcome(
+      data = d, intervention_components_coeff = coeff, power_goal = 0.8,
+      power_goal_approach = approach, num_centers_in_next_stage = 20,
+      patients_per_center_in_next_stage = 20, outcome_name = "y",
+      icc = icc,
+      power_goal_cluster_id = if (is.null(icc) || all(icc == 0)) NULL else "center"
+    ))
+  }
+  for (approach in c("unconditional", "conditional")) {
+    r0 <- call_icc(0, approach)
+    r_small <- call_icc(0.01, approach)
+    r_big <- call_icc(0.03, approach)
+    # monotone non-decreasing, and strictly higher somewhere (not saturated flat)
+    expect_true(r0 <= r_small)
+    expect_true(r_small <= r_big)
+    expect_true(r_big > r0)
+  }
+})
+
+test_that("the shipped both-stage formula matches an independent reference solver", {
+  # Pin the ACTUAL get_power_desired_outcome() output against an independent
+  # re-implementation of the unconditional both-stage variance. This calls the
+  # real function (not just its own formula), so a DE1/DE2 swap, a
+  # whole-variance multiply, or a stage-2-only form in the code would fail here
+  # even though it might pass a monotonicity test.
+  d <- make_small_clustered()
+  coeff <- small_coeff(d)
+  icc <- 0.02
+  j <- 20
+  n2j <- 20
+
+  # independent reference: replicate get_power_desired_outcome's grid search
+  # with the both-stage variance built here from scratch.
+  ref_required_outcome <- function() {
+    required_ncp <- stats::uniroot(function(ncp) {
+      (1 - stats::pchisq(stats::qchisq(0.95, 1), 1, ncp)) - 0.8
+    }, c(0, 100))$root
+    de2 <- 1 + (n2j - 1) * icc
+    de1_arm <- function(grp) {
+      m <- as.numeric(table(d[d$group == grp, "center"]))
+      m1 <- sum(m^2) / sum(m)
+      1 + (m1 - 1) * icc
+    }
+    de1_int <- de1_arm("treatment")
+    de1_ctl <- de1_arm("control")
+    n1_1 <- sum(d$group == "treatment")
+    n0_1 <- sum(d$group == "control")
+    n1_2 <- n0_2 <- j / 2 * n2j
+    N1 <- n1_1 + n1_2
+    N0 <- n0_1 + n0_2
+    S1_1 <- sum(d$y[d$group == "treatment"])
+    S0_1 <- sum(d$y[d$group == "control"])
+    beta0 <- coeff[["(Intercept)"]]
+    grid <- seq(rje::expit(beta0), 1, length.out = 1000)
+    ncp <- vapply(grid, function(ep) {
+      S1_2 <- n1_2 * ep
+      S0_2 <- n0_2 * rje::expit(beta0)
+      p1 <- (S1_1 + S1_2) / N1
+      p0 <- (S0_1 + S0_2) / N0
+      v1 <- p1 * (1 - p1) * (de1_int * n1_1 + de2 * n1_2) / N1^2
+      v0 <- p0 * (1 - p0) * (de1_ctl * n0_1 + de2 * n0_2) / N0^2
+      ((p1 - p0) / sqrt(v1 + v0))^2
+    }, numeric(1))
+    idx <- which(ncp >= required_ncp)
+    ctl_pct <- S0_1 / n0_1
+    pos <- grid[idx]
+    pos[pos > ctl_pct][1]
+  }
+
+  shipped <- suppressWarnings(get_power_desired_outcome(
+    data = d, intervention_components_coeff = coeff, power_goal = 0.8,
+    power_goal_approach = "unconditional", num_centers_in_next_stage = j,
+    patients_per_center_in_next_stage = n2j, outcome_name = "y",
+    icc = icc, power_goal_cluster_id = "center"
+  ))
+  expect_equal(shipped, ref_required_outcome(), tolerance = 1e-6)
+})
+
+test_that("the conditional path matches an independent reference (DE inside sqrt, not DE^2)", {
+  # Pin the real conditional get_power_desired_outcome() against an independent
+  # reimplementation. de2_power = 1 is the correct DE-inside-sqrt form; a DE^2
+  # bug on the sd-form sigma_hat_x_2 (multiplying the sd by DE instead of the
+  # variance inside the sqrt) corresponds to de2_power = 2 and is caught by the
+  # tight (1e-6) pin below.
+  d <- make_small_clustered()
+  coeff <- small_coeff(d)
+  icc <- 0.02
+  j <- 20
+  n2j <- 20
+
+  ref_conditional <- function(de2_power) {
+    z <- stats::qnorm(1 - 0.05 / 2)
+    z_pi <- stats::qnorm(0.8)
+    beta0 <- coeff[["(Intercept)"]]
+    de2 <- 1 + (n2j - 1) * icc
+    de1_arm <- function(grp) {
+      mm <- as.numeric(table(d[d$group == grp, "center"]))
+      1 + (sum(mm^2) / sum(mm) - 1) * icc
+    }
+    de1_int <- de1_arm("treatment")
+    de1_ctl <- de1_arm("control")
+    n1_1 <- sum(d$group == "treatment")
+    n0_1 <- sum(d$group == "control")
+    n1_2 <- n0_2 <- j / 2 * n2j
+    N1 <- n1_1 + n1_2
+    N0 <- n0_1 + n0_2
+    S1_1 <- sum(d$y[d$group == "treatment"])
+    S0_1 <- sum(d$y[d$group == "control"])
+    grid <- seq(rje::expit(beta0), 1, length.out = 1000)
+    vals <- vapply(grid, function(ep) {
+      S1_2 <- n1_2 * ep
+      S0_2 <- n0_2 * rje::expit(beta0)
+      p1 <- (S1_1 + S1_2) / N1
+      p0 <- (S0_1 + S0_2) / N0
+      sp1 <- p1 * (1 - p1) * (de1_int * n1_1 + de2 * n1_2) / N1^2
+      sp2 <- p0 * (1 - p0) * (de1_ctl * n0_1 + de2 * n0_2) / N0^2
+      z_part <- z * sqrt(sp1 + sp2)
+      mu <- n1_2 * ep / N1 - n0_2 * rje::expit(beta0) / N0
+      # de2_power = 1: DE inside the sqrt (correct). de2_power = 2: the DE^2 bug.
+      sig <- sqrt(
+        (de2^de2_power) * n0_2 * rje::expit(beta0) * (1 - rje::expit(beta0)) / N0^2 +
+          (de2^de2_power) * n1_2 * ep * (1 - ep) / N1^2
+      )
+      z_part - S1_1 / N1 + S0_1 / N0 - mu + z_pi * sig
+    }, numeric(1))
+    poss <- grid[vals <= 0]
+    if (length(poss) > 0) poss[1] else 0
+  }
+
+  shipped <- suppressWarnings(get_power_desired_outcome(
+    data = d, intervention_components_coeff = coeff, power_goal = 0.8,
+    power_goal_approach = "conditional", num_centers_in_next_stage = j,
+    patients_per_center_in_next_stage = n2j, outcome_name = "y",
+    icc = icc, power_goal_cluster_id = "center"
+  ))
+  # matches the correct (DE-inside-sqrt) reference ...
+  expect_equal(shipped, ref_conditional(1), tolerance = 1e-6)
+  # ... and is distinguishable from the DE^2 form (guards the sd-vs-var trap).
+  expect_false(isTRUE(all.equal(shipped, ref_conditional(2), tolerance = 1e-6)))
+})
+
+test_that("icc validation rejects bad inputs", {
+  d <- make_small_clustered()
+  base <- list(
+    data = transform(d, dose = ifelse(group == "treatment", 1, 0)),
+    outcome_name = "y", outcome_type = "binary",
+    intervention_components = "dose",
+    intervention_lower_bounds = 0, intervention_upper_bounds = 1,
+    cost_list_of_vectors = list(c(0, 1)),
+    power_goal = 0.8, num_centers_in_next_stage = 4,
+    patients_per_center_in_next_stage = 8, include_confidence_set = FALSE
+  )
+  # out of range
+  expect_error(
+    suppressWarnings(suppressMessages(do.call(
+      lago_optimization, c(base, list(icc = 1.2, power_goal_cluster_id = "center"))
+    ))),
+    "\\[0, 1\\)"
+  )
+  expect_error(
+    suppressWarnings(suppressMessages(do.call(
+      lago_optimization, c(base, list(icc = -0.1, power_goal_cluster_id = "center"))
+    ))),
+    "\\[0, 1\\)"
+  )
+  # wrong length
+  expect_error(
+    suppressWarnings(suppressMessages(do.call(
+      lago_optimization,
+      c(base, list(icc = c(0.1, 0.1, 0.1), power_goal_cluster_id = "center"))
+    ))),
+    "length 1"
+  )
+  # non-zero icc without a cluster id
+  expect_error(
+    suppressWarnings(suppressMessages(do.call(
+      lago_optimization, c(base, list(icc = 0.05))
+    ))),
+    "power_goal_cluster_id"
+  )
+  # cluster id column absent
+  expect_error(
+    suppressWarnings(suppressMessages(do.call(
+      lago_optimization, c(base, list(icc = 0.05, power_goal_cluster_id = "nope"))
+    ))),
+    "not found"
+  )
+})
+
+test_that("icc without a power goal is ignored with a message", {
+  # assert directly on validate_inputs(), which is where the message is emitted.
+  # Going through the full lago_optimization() here is fragile: these small
+  # fixtures can trip unrelated pre-existing issues in the optimizer, which
+  # would mask (or crash before) this assertion.
+  d <- transform(make_small_clustered(), dose = ifelse(group == "treatment", 1, 0))
+  expect_message(
+    validate_inputs(
+      data = d, outcome_name = "y", outcome_type = "binary",
+      intervention_components = "dose",
+      intervention_lower_bounds = 0, intervention_upper_bounds = 1,
+      outcome_goal = 0.6, outcome_goal_intention = "maximize",
+      power_goal = NULL, power_goal_approach = "unconditional",
+      cost_list_of_vectors = list(c(0, 1)), icc = 0.05
+    ),
+    "icc is ignored"
+  )
+})
+
+test_that("an infeasible design effect warns instead of silently dropping the goal", {
+  d <- make_small_clustered()
+  coeff <- small_coeff(d)
+  # large icc + tiny next stage -> required outcome unreachable
+  expect_warning(
+    get_power_desired_outcome(
+      data = d, intervention_components_coeff = coeff, power_goal = 0.8,
+      power_goal_approach = "unconditional", num_centers_in_next_stage = 4,
+      patients_per_center_in_next_stage = 8, outcome_name = "y",
+      icc = 0.3, power_goal_cluster_id = "center"
+    ),
+    "infeasible"
+  )
+  expect_warning(
+    get_power_desired_outcome(
+      data = d, intervention_components_coeff = coeff, power_goal = 0.99,
+      power_goal_approach = "conditional", num_centers_in_next_stage = 4,
+      patients_per_center_in_next_stage = 8, outcome_name = "y",
+      icc = 0.5, power_goal_cluster_id = "center"
+    ),
+    "infeasible"
+  )
+})
+
+test_that("BB_data backward compatibility: icc = NULL matches the pre-icc result", {
+  bb <- BB_data
+  bb$group <- ifelse(bb$pre_post == 0, "control", "treatment")
+  args <- list(
+    data = bb, outcome_name = "pp3_oxytocin_mother", outcome_type = "binary",
+    intervention_components = c("coaching_updt", "launch_duration"),
+    center_characteristics = "birth_volume_100",
+    center_characteristics_optimization_values = 1.75,
+    intervention_lower_bounds = c(1, 1), intervention_upper_bounds = c(40, 5),
+    cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+    power_goal = 0.8, num_centers_in_next_stage = 10,
+    patients_per_center_in_next_stage = 30, include_confidence_set = FALSE
+  )
+  null_res <- suppressWarnings(suppressMessages(do.call(lago_optimization, args)))
+  zero_res <- suppressWarnings(suppressMessages(do.call(
+    lago_optimization,
+    c(args, list(icc = 0, power_goal_cluster_id = "site_name"))
+  )))
+  expect_equal(null_res$est_outcome_goal, zero_res$est_outcome_goal)
+})


### PR DESCRIPTION
The power calculation assumed independent observations, overstating power for clustered trials. Add an optional 'icc' argument (with 'power_goal_cluster_id') that inflates the power-calculation variance by a design effect, following the LAGO power paper (arXiv 2509.11479):

- unconditional (Theorem 1, stage-1 random): both stages are clustered, Var = p(1-p)*(DE1*n_stage1 + DE2*n_stage2)/N^2, with DE1 from the size-biased stage-1 cluster size and DE2 = 1+(n2j-1)*icc.
- conditional (Theorem 2, stage-1 fixed): the stage-2 prediction variance clusters stage-2 only; the rejection-threshold SE uses the both-stage form.

icc = NULL (default) reproduces the original behavior bit-for-bit; icc = 0 is identical. icc may be a scalar or a length-2 c(control, treatment) vector. A non-zero icc requires power_goal_cluster_id and at least two centers per arm. When a design effect makes the power goal infeasible, both approaches now warn explicitly instead of silently returning the unreachable-outcome (1) or the power-goal-dropping (0) sentinel.

Adds validation, roxygen docs, a testthat suite (backward-compat, per-approach formula pins against independent reference solvers, per-arm icc, infeasible warnings, validation errors), and a manual test.