### PR TITLE
Update README: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ The LAGO R package bridges the gap between theoretical advances in Learn-As-you-
 1) fitting the outcome models for both binary and continuous outcomes, including support for fixed center effects/center characteristics and fixed time effects,
 2) calculating the recommended interventions based on various optimization criteria, including support for custom cost functions,
 3) estimating the optimal intervention based on data from all stages,
-4) calculating the 95\% confidence sets for the recommended interventions and the optimal interventions.
+4) calculating the 95% confidence sets for the recommended interventions and the optimal interventions.
 
 ### Table of Contents
 1. [How to install the R package](#how-to-install-the-r-package)
 2. [The main functions](#the-main-functions)
 3. [Basic use case](#basic-use-case)
 4. [More advanced use case](#more-advanced-use-case)
-5. [Additional examples in the R package](#how-to-run-additional-examples)
+5. [How to run additional examples](#how-to-run-additional-examples)
 6. [Relevant LAGO papers](#relevant-lago-papers)
 7. [How to get help](#how-to-get-help)
 
 
-### How to install the R package 
+### How to install the R package
 - Method 1 (directly using RStudio):
   ```
   install.packages("devtools")
@@ -27,29 +27,29 @@ The LAGO R package bridges the gap between theoretical advances in Learn-As-you-
   ```
 - Method 2: Clone this repo into RStudio, you can follow the directions provided [in this video](https://www.youtube.com/watch?v=NInwldFZgwA&t=275s).
 
-### The main functions 
-The LAGO R package has two user-facing functions `lago_optimization()` and `visualize_cost()`. 
+### The main functions
+The LAGO R package has two user-facing functions `lago_optimization()` and `visualize_cost()`.
 
-`lago_optimization()` carries out the LAGO optimizations, and `visualize_cost()` helps users to determine the cost function of intervention components.
+`lago_optimization()` carries out the LAGO optimizations, and `visualize_cost()` helps you choose cost functions for the intervention components.
 
-`lago_optimization()` supports three goal modes: an **outcome goal alone**, a **power goal alone**, or **both together**. At least one of `outcome_goal` or `power_goal` must be provided. When both are provided, the effective outcome goal used for the optimization is the higher of the outcome goal and the outcome level implied by the power goal (the "whichever is higher" rule). A power goal is only supported for binary outcomes and requires a `group` column plus `num_centers_in_next_stage` and `patients_per_center_in_next_stage`; it cannot be combined with `outcome_goal_intention = "minimize"`.
+`lago_optimization()` supports three goal modes: an **outcome goal alone**, a **power goal alone**, or **both together**. At least one of `outcome_goal` or `power_goal` must be provided. When both are provided, the effective outcome goal used for the optimization is the higher of the outcome goal and the outcome level implied by the power goal (the "whichever is higher" rule). A power goal is only supported for binary outcomes and requires a `group` column plus `num_centers_in_next_stage` and `patients_per_center_in_next_stage`; it cannot be combined with `outcome_goal_intention = "minimize"`. When participants are clustered within centers, pass the intra-cluster correlation to `icc` (a single value, or `c(control, treatment)`) and identify the clustering column with `power_goal_cluster_id`. The power calculation then inflates the variance of the test statistic by the design effect, so meeting the same power goal requires a stronger intervention. Without `icc`, the power calculation treats participants as independent.
 
-Both functions have multiple arguments, and it is impractical to list them all here.
-To get a better understanding of the input arguments, please take a look at the help files by running the following code in R **(this step is HIGHLY recommended, please do this before moving on to the examples)**:
+Both functions take many arguments.
+To understand the input arguments, read the help files by running the following code in R **(this step is HIGHLY recommended, please do this before moving on to the examples)**:
 ```
 help(lago_optimization)
 help(visualize_cost)
 ```
 
 ### Basic use case
-We consider a hypothetical example based on a very well-known R built-in dataset: 'mtcars' to showcase how the LAGO package works. This example may not make practical sense, it is intended to be an example that describes how to run LAGO optimization for a real-world dataset.  
+We consider a hypothetical example based on the built-in R dataset 'mtcars'. The scenario is contrived; its purpose is to demonstrate the mechanics of running a LAGO optimization on a real dataset.
 
 The 'mtcars' data was extracted from the 1974 Motor Trend US magazine, and comprises fuel consumption and 10 aspects of automobile design and performance for 32 automobiles (1973–74 models).
 Here, we only focus on the following variables: 'mpg' - miles per gallon, 'gear' - number of forward gears, and 'qsec' - quarter mile time in seconds.
 
-Suppose that 'mpg' is our outcome of interest, and 'gear' and 'qsec' are the two intervention components. We are interested in estimating the optimal intervention package (values of 'gear' and 'qsec') that is expected to achieve an outcome goal of 40 miles per gallon. We expect that the estimated outcome without any intervention is going to be less than 40, and implementing the two intervention components can increase the value of the outcome (which corresponds to setting `outcome_goal_intention = "maximize"`). We are also interested in obtaining the 95% confidence set, which is a list of intervention package compositions that can be expected to include the optimal intervention in 95% of such trials. For the confidence set, we are only interested in the integer values of the intervention components, which corresponds to setting `confidence_set_grid_step_size = c(1, 1)`. 
+Suppose that 'mpg' is our outcome of interest, and 'gear' and 'qsec' are the two intervention components. We are interested in estimating the recommended intervention package (values of 'gear' and 'qsec') that is expected to achieve an outcome goal of 40 miles per gallon. We expect that the estimated outcome without any intervention is going to be less than 40, and implementing the two intervention components can increase the value of the outcome (which corresponds to setting `outcome_goal_intention = "maximize"`). We are also interested in obtaining the 95% confidence set, which is a list of intervention package compositions that can be expected to include the optimal intervention in 95% of such trials. For the confidence set, we are only interested in the integer values of the intervention components, which corresponds to setting `confidence_set_grid_step_size = c(1, 1)`.
 
-Since 'mpg' is a continuous variable, we can fit a linear regression between the outcome 'mpg' and the predictors 'gear' and 'qsec'. Then, suppose that we know the lower and upper bounds of 'gear' and 'qsec' are: 0 <= 'gear' <= 10 and 0 <= 'qsec' <= 350, and the total monetary cost of implementing the 'gear' ($x_1$) and 'qsec' ($x_2$) are $C(x_1) = 4x_1$, and $C(x_2) = 4 + 6x_2$, respectively. 
+Since 'mpg' is a continuous variable, we can fit a linear regression of the outcome 'mpg' on the predictors 'gear' and 'qsec'. Then, suppose that we know the lower and upper bounds of 'gear' and 'qsec' are: 0 <= 'gear' <= 10 and 0 <= 'qsec' <= 350, and the total monetary cost of implementing the 'gear' ($x_1$) and 'qsec' ($x_2$) are $C(x_1) = 4x_1$, and $C(x_2) = 4 + 6x_2$, respectively.
 
 For running LAGO optimizations:
 ```
@@ -81,7 +81,7 @@ Typical output:
 ℹ Calculating the recommended intervention...
 ✔ Done
 ℹ Calculating the confidence set...
-If the confidence set calculation takes a long time to run, please consider changing the confidence set step size. 
+If the confidence set calculation takes a long time to run, please consider changing the confidence set step size.
 ✔ Done
 → ♥ LAGO optimization complete ♥
 ℹ Printing the output...
@@ -89,21 +89,21 @@ If the confidence set calculation takes a long time to run, please consider chan
 ==================================
 ============  Inputs  ============
 ==================================
-Input data dimensions: 32 rows, and 13 columns 
-Outcome name: mpg 
-Outcome type: continuous 
-2 intervention package component(s): 
+Input data dimensions: 32 rows, and 13 columns
+Outcome name: mpg
+Outcome type: continuous
+2 intervention package component(s):
          gear
-         qsec 
-The outcome model: 
-         family: gaussian 
-         link: identity 
-         fixed center effects: FALSE 
-         fixed time effects: FALSE 
-Outcome goal: 40 
-List of intervention component costs: c(0, 4), c(4, 6) 
-Intervention lower bounds: 0 0 
-Intervention upper bounds: 10 350 
+         qsec
+The outcome model:
+         family: gaussian
+         link: identity
+         fixed center effects: FALSE
+         fixed time effects: FALSE
+Outcome goal: 40
+List of intervention component costs: c(0, 4), c(4, 6)
+Intervention lower bounds: 0 0
+Intervention upper bounds: 10 350
 
 =====================================
 ============  Model Fit  ============
@@ -113,8 +113,8 @@ Call:
 glm(formula = formula, family = family_object, data = data, weights = weights)
 
 Coefficients:
-            Estimate Std. Error t value Pr(>|t|)    
-(Intercept) -30.7108     9.6702  -3.176 0.003530 ** 
+            Estimate Std. Error t value Pr(>|t|)
+(Intercept) -30.7108     9.6702  -3.176 0.003530 **
 gear          4.8711     1.0814   4.505 0.000100 ***
 qsec          1.8399     0.4465   4.121 0.000288 ***
 ---
@@ -136,15 +136,15 @@ Number of Fisher Scoring iterations: 2
       gear 10.00000
       qsec 11.95743
 
-Cost for using the recommended interventions: 115.7446 
-Estimated outcome goal using the recommended interventions: 40 
+Cost for using the recommended interventions: 115.7446
+Estimated outcome goal using the recommended interventions: 40
 
 ========================================
 ============ Confidence Set ============
 ========================================
-Confidence set size percentage: 0.04247604 
-Confidence set (only first few rows are shown): 
-Please use $cs to get the full confidence set. 
+Confidence set size percentage: 0.04247604
+Confidence set (only first few rows are shown):
+Please use $cs to get the full confidence set.
    gear qsec CI_lower_bound CI_upper_bound cost
 44   10    3          6.902         40.137   62
 55   10    4          9.261         41.458   68
@@ -153,15 +153,14 @@ Please use $cs to get the full confidence set.
 88   10    7         16.136         45.622   86
 98    9    8         15.118         40.577   88
 ```
-From the output above, we see that both 'gear' and 'qsec' have positive effects on 'mpg', and the optimal intervention turns out to be 'gear' = 10, and 'qsec' = 11.96. 
+From the output above, we see that both 'gear' and 'qsec' have positive effects on 'mpg', and the recommended intervention is 'gear' = 10 and 'qsec' = 11.96.
 
 
-You may not be satisfied with the current cost function $C(x_1) = 4x_1$, and $C(x_2) = 4 + 6x_2$. 
-The LAGO R package offers an intuitive way to help you visualize and select cost functions:
+To adjust the cost functions $C(x_1) = 4x_1$ and $C(x_2) = 4 + 6x_2$, `visualize_cost()` lets you visualize and select cost functions:
 
-The `visualize_cost` function creates a Shiny app that allows the user to adjust the coefficients of the cost functions for each intervention component and visualize the resulting total cost function and unit cost function. The initial coefficients are calculated based on the unit costs, the default cost function type (linear or cubic), and the lower and upper bounds. 
+`visualize_cost()` creates a Shiny app that allows the user to adjust the coefficients of the cost functions for each intervention component and visualize the resulting total cost function and unit cost function. The initial coefficients are calculated based on the unit costs, the default cost function type (linear or cubic), and the lower and upper bounds.
 
-The user can adjust the coefficients using sliders and reset them to their initial values. The app also displays the current coefficient vector for each component. The user can copy the final coefficient list (at the bottom of the app) for use in the optimization function lago_optimization().
+The user can adjust the coefficients using sliders and reset them to their initial values. The app also displays the current coefficient vector for each component. The user can copy the final coefficient list (at the bottom of the app) for use in `lago_optimization()`.
 
 ```
 visualize_cost(
@@ -172,23 +171,23 @@ visualize_cost(
   intervention_upper_bounds = c(10, 10)
 )
 ```
-The following gif shows the expected behavior of the R shiny app 
+The GIF below shows the Shiny app in action
 
-**(please wait a few seconds for the gif to load)**
-![screenshot of the cost function r shiny app basic example](./images/shiny_2_14_2025.gif)
+**(please wait a few seconds for the GIF to load)**
+![the visualize_cost Shiny app](./images/shiny_2_14_2025.gif)
 
 
 ### More advanced use case
-We consider a more complicated example, which is adapted from Nevo et al., 2021. 
+We consider a more complicated example, which is adapted from Nevo et al., 2021.
 
 Suppose we want to run LAGO optimization for the BetterBirth Study, a costly failed trial of maternal and newborn care that took place in Uttar Pradesh, India (Hirschhorn et al. 2015; Semrau et al. 2017).
-The BetterBirth Study assessed the use of the World Health Organization’s (WHO) Safe ChildBirth checklist, a 31-item checklist of best labor and delivery practices believed to be feasible in resource-limited settings, to reduce maternal and neonatal mortality. The intervention was adapted and tested in a three phase process, where neonatal mortality is 32 per 1000 live births and maternal mortality is 258 per 100,000 births (Semrau et al. (2017)). 
+The BetterBirth Study assessed the use of the World Health Organization’s (WHO) Safe Childbirth Checklist, a 31-item checklist of best labor and delivery practices believed to be feasible in resource-limited settings, to reduce maternal and neonatal mortality. The intervention was adapted and tested in a three-phase process. In this setting, neonatal mortality is 32 per 1,000 live births and maternal mortality is 258 per 100,000 births (Semrau et al. 2017).
 
 Suppose that we want to identify the optimal intervention package such that the cost of the intervention is minimized and the probability of a desired binary outcome, oxytocin administered ('pp3_oxytocin_mother'), is above a given threshold (85%).
-The two intervention components that we are interested in are 'coaching_updt' ($x_1$), the number of coaching update, and 'launch duration' ($x_2$), the number of days in launch duration. Suppose that we know the lower and upper bounds of 'coaching_updt' and 'launch_duration' are [1,40] and [1,5], respectively. The total costs of the two components are $C(x_1) = 1.7x_1$, and $C(x_2) = 8x_2$, respectively.
-In addition, we assign fake centers and fake time periods to all observations as a way to demonstrate the R package's capability to fit outcome models with fixed center and fixed time effects. 
+The two intervention components are 'coaching_updt' ($x_1$), the number of coaching updates, and 'launch_duration' ($x_2$), the launch duration in days. Suppose that we know the lower and upper bounds of 'coaching_updt' and 'launch_duration' are [1,40] and [1,5], respectively. The total costs of the two components are $C(x_1) = 1.7x_1$, and $C(x_2) = 8x_2$, respectively.
+In addition, we assign fake centers and fake time periods to all observations to demonstrate fitting outcome models with fixed center and fixed time effects.
 
-For the optimal intervention, instead of an overall optimal intervention package, we are interested in an optimal intervention package that is specifically for center "5" in time period "10". 
+Instead of an overall optimal intervention package, we target the optimal intervention package for center "5" in time period "10".
 
 ```
 # The BetterBirth data has been open sourced so a version of
@@ -233,7 +232,7 @@ Output:
 ℹ Calculating the recommended intervention...
 ✔ Done
 ℹ Calculating the confidence set...
-If the confidence set calculation takes a long time to run, please consider changing the confidence set step size. 
+If the confidence set calculation takes a long time to run, please consider changing the confidence set step size.
 ✔ Done
 → ♥ LAGO optimization complete ♥
 ℹ Printing the output...
@@ -241,21 +240,21 @@ If the confidence set calculation takes a long time to run, please consider chan
 ==================================
 ============  Inputs  ============
 ==================================
-Input data dimensions: 6124 rows, and 23 columns 
-Outcome name: pp3_oxytocin_mother 
-Outcome type: binary 
-2 intervention package component(s): 
+Input data dimensions: 6124 rows, and 23 columns
+Outcome name: pp3_oxytocin_mother
+Outcome type: binary
+2 intervention package component(s):
          coaching_updt
-         launch_duration 
-The outcome model: 
-         family: binomial 
-         link: logit 
-         fixed center effects: TRUE 
-         fixed time effects: TRUE 
-Outcome goal: 0.85 
-List of intervention component costs: c(0, 1.7), c(0, 8) 
-Intervention lower bounds: 1 1 
-Intervention upper bounds: 40 5 
+         launch_duration
+The outcome model:
+         family: binomial
+         link: logit
+         fixed center effects: TRUE
+         fixed time effects: TRUE
+Outcome goal: 0.85
+List of intervention component costs: c(0, 1.7), c(0, 8)
+Intervention lower bounds: 1 1
+Intervention upper bounds: 40 5
 
 =====================================
 ============  Model Fit  ============
@@ -265,27 +264,27 @@ Call:
 glm(formula = formula, family = family_object, data = data, weights = weights)
 
 Coefficients:
-                  Estimate Std. Error z value Pr(>|z|)    
+                  Estimate Std. Error z value Pr(>|z|)
 (Intercept)     -7.947e-01  1.345e-01  -5.908 3.47e-09 ***
-center2          1.419e-01  1.361e-01   1.043    0.297    
-center3          8.206e-02  1.370e-01   0.599    0.549    
-center4         -8.730e-02  1.384e-01  -0.631    0.528    
-center5          1.790e-02  1.374e-01   0.130    0.896    
-center6         -1.491e-01  1.413e-01  -1.056    0.291    
-center7         -1.222e-01  1.362e-01  -0.897    0.370    
-center8         -2.050e-01  1.381e-01  -1.485    0.138    
-center9         -2.467e-02  1.380e-01  -0.179    0.858    
-center10         1.240e-01  1.375e-01   0.902    0.367    
-period2         -1.455e-01  1.386e-01  -1.050    0.294    
-period3          5.545e-02  1.348e-01   0.411    0.681    
-period4         -1.545e-01  1.425e-01  -1.084    0.278    
-period5         -3.372e-02  1.392e-01  -0.242    0.809    
-period6          3.380e-02  1.377e-01   0.246    0.806    
-period7         -1.417e-01  1.415e-01  -1.002    0.316    
-period8          1.252e-02  1.363e-01   0.092    0.927    
-period9         -1.844e-01  1.364e-01  -1.353    0.176    
-period10         1.041e-01  1.362e-01   0.764    0.445    
-coaching_updt   -2.997e-05  7.668e-03  -0.004    0.997    
+center2          1.419e-01  1.361e-01   1.043    0.297
+center3          8.206e-02  1.370e-01   0.599    0.549
+center4         -8.730e-02  1.384e-01  -0.631    0.528
+center5          1.790e-02  1.374e-01   0.130    0.896
+center6         -1.491e-01  1.413e-01  -1.056    0.291
+center7         -1.222e-01  1.362e-01  -0.897    0.370
+center8         -2.050e-01  1.381e-01  -1.485    0.138
+center9         -2.467e-02  1.380e-01  -0.179    0.858
+center10         1.240e-01  1.375e-01   0.902    0.367
+period2         -1.455e-01  1.386e-01  -1.050    0.294
+period3          5.545e-02  1.348e-01   0.411    0.681
+period4         -1.545e-01  1.425e-01  -1.084    0.278
+period5         -3.372e-02  1.392e-01  -0.242    0.809
+period6          3.380e-02  1.377e-01   0.246    0.806
+period7         -1.417e-01  1.415e-01  -1.002    0.316
+period8          1.252e-02  1.363e-01   0.092    0.927
+period9         -1.844e-01  1.364e-01  -1.353    0.176
+period10         1.041e-01  1.362e-01   0.764    0.445
+coaching_updt   -2.997e-05  7.668e-03  -0.004    0.997
 launch_duration  1.375e+00  8.744e-02  15.726  < 2e-16 ***
 ---
 Signif. codes:  0 ‘***’ 0.001 ‘**’ 0.01 ‘*’ 0.05 ‘.’ 0.1 ‘ ’ 1
@@ -309,19 +308,19 @@ To see the overall test results, please include a 'group' column in the data,
        component    value
    coaching_updt 1.000000
  launch_duration 1.750754
-Estimated outcome goal using the recommended interventions: 0.85 
-95% confidence interval for the estimated outcome goal: 0.802 - 0.898 
+Estimated outcome goal using the recommended interventions: 0.85
+95% confidence interval for the estimated outcome goal: 0.802 - 0.898
 
-Cost for using the recommended interventions: 15.70603 
+Cost for using the recommended interventions: 15.70603
 
 ========================================
 ============ Confidence Set ============
 ========================================
-Confidence set size percentage: 0.1185185 
-IQR of the cost within the 95% confidence set: 32.4 - 67.75 
+Confidence set size percentage: 0.1185185
+IQR of the cost within the 95% confidence set: 32.4 - 67.75
 
-Confidence set (only first few rows are shown): 
-Please use $cs to get the full confidence set. 
+Confidence set (only first few rows are shown):
+Please use $cs to get the full confidence set.
    coaching_updt launch_duration CI_lower_bound CI_upper_bound cost
 78            33            1.45          0.726          0.853 67.7
 79            35            1.45          0.722          0.856 71.1
@@ -330,18 +329,44 @@ Please use $cs to get the full confidence set.
 82             1            1.60          0.769          0.874 14.5
 83             3            1.60          0.772          0.872 17.9
 ```
-From the output, notice that the model fitting results are a lot more complicated than those from the previous example. 
+The model fit here includes many more coefficients, one per center and per time period, than the previous example.
 
 
 ### How to run additional examples
-Please note that this readme file does not cover all the details of the input arguments, various aspects of the outcome model, and additional details of the optimization algorithm for calculating the recommended interventions. 
+This README does not document every input argument, every component of the outcome model, or the optimization algorithm behind the recommended interventions.
 
-**You can also fit 'center-level' data, change the optimization method, include interaction terms and additional covariates, carry out a test for overall intervention effect, etc. 
-Please refer to R help files and example from the [manual tests](https://github.com/correspondMerchant/LAGO-R-Package/tree/main/tests/manual_tests) folder for details.** 
+**You can also fit 'center-level' data, change the optimization method, add interaction terms and covariates, and test for an overall intervention effect.
+Please refer to the R help files and the examples in the [manual tests](https://github.com/correspondMerchant/LAGO-R-Package/tree/main/tests/manual_tests) folder for details.**
 
 You can start with the simpler ones, like the [identity link with built-in dataset](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_rec_int_for_cts_identity.Rmd), or the [logistic link with the BetterBirth dataset](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_rec_int_for_BB_data.Rmd) before moving on to other files.
 
-If you want to learn how to include a power goal, please start with the file [test_binary_power_goal](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_binary_power_goal.Rmd), where the BetterBirth data is used. Note that you need to add a `group` column in the data before calling `lago_optimization`. Also, the `unconditional` power approach is used by default, you can do `power_goal_approach = "conditional"` to use the conditional power approach instead. 
+If you want to learn how to include a power goal, please start with the file [test_binary_power_goal](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_binary_power_goal.Rmd), where the BetterBirth data is used. You must add a `group` column to the data before calling `lago_optimization()`. The `unconditional` power approach is the default; set `power_goal_approach = "conditional"` to use the conditional approach instead. To account for within-center clustering in the power calculation, see [test_icc_power](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_icc_power.Rmd), which shows how the `icc` argument shifts the recommended intervention.
+
+The complete set of runnable `.Rmd` examples, grouped by topic:
+
+Recommended interventions:
+- [test_rec_int_for_cts_identity](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_rec_int_for_cts_identity.Rmd) — continuous outcome with an identity link, on the built-in `mtcars` dataset.
+- [test_rec_int_for_BB_data](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_rec_int_for_BB_data.Rmd) — binary outcome with a logistic link, on the BetterBirth dataset.
+- [test_rec_int_for_BB_data_cts](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_rec_int_for_BB_data_cts.Rmd) — BetterBirth proportions modeled as a continuous outcome.
+
+Goal modes and power:
+- [test_goal_modes](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_goal_modes.Rmd) — three goal modes: an outcome goal alone, a power goal alone, and both together.
+- [test_binary_power_goal](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_binary_power_goal.Rmd) — power goal for a binary outcome, under the unconditional and conditional approaches.
+- [test_icc_power](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_icc_power.Rmd) — within-center clustering in the power calculation, via `icc`.
+
+Cost functions:
+- [test_default_cost_function](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_default_cost_function.Rmd) — default cost function derived from unit costs and bounds.
+- [test_higher_order_costs](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_higher_order_costs.Rmd) — higher-order (for example, cubic) cost functions.
+- [test_visualize_cost](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_visualize_cost.Rmd) — `visualize_cost()` Shiny app for choosing cost-function coefficients.
+
+Confidence set and the optimization algorithm:
+- [test_confidence_set](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_confidence_set.Rmd) — 95% confidence set, and how to read its size and cost range.
+- [test_shrinking_method](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_shrinking_method.Rmd) — shrinking method, used when the outcome goal is not reachable.
+- [test_shrinking_with_power_goal](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_shrinking_with_power_goal.Rmd) — shrinking method under a power goal.
+
+Outcome model and testing:
+- [test_fit_diagnostics](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_fit_diagnostics.Rmd) — fit diagnostics that warn about a questionable outcome model (glm warnings, near-singular estimates, non-significant components) while the optimization continues.
+- [test_overall_intervention](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_overall_intervention.Rmd) — overall intervention-effect test, reported when a `group` column is supplied.
 
 ### Relevant LAGO papers
 1. [Nevo D, Lok JJ, Spiegelman D. ANALYSIS OF "LEARN-AS-YOU-GO" (LAGO) STUDIES. Ann Stat. 2021 Apr;49(2):793-819. doi: 10.1214/20-aos1978. Epub 2021 Apr 2. PMID: 35510045; PMCID: PMC9067111.](https://pmc.ncbi.nlm.nih.gov/articles/PMC9067111/pdf/nihms-1761299.pdf)
@@ -349,8 +374,8 @@ If you want to learn how to include a power goal, please start with the file [te
 3. [Bing A, Spiegelman D, Lok JJ. Learn-As-you-GO (LAGO) Trials: Optimizing Trials for Effectiveness and Power to Prevent Failed Trials. arXiv:2509.11479](https://arxiv.org/pdf/2509.11479)
 4. [Bui, M. T., Longenecker, C. T., Bing, A., Spiegelman, D., Webel, A. R., Bosworth, H. B., & Lok, J. J. (2026). Addressing Confounding by Indication Through (Un) Measured Centre Characteristics in Learn-As-you-GO (LAGO) Trials. arXiv preprint arXiv:2604.13276.](https://arxiv.org/abs/2604.13276)
 
-### How to get help 
-Before reaching out for help, please carefully review this readme file, examine the descriptions of the arguments in R help files, run the Rmd files in the [manual tests](https://github.com/correspondMerchant/LAGO-R-Package/tree/main/tests/manual_tests) folder, and read relevant LAGO papers. 
+### How to get help
+Before reaching out for help, please carefully review this README, examine the descriptions of the arguments in the R help files, run the `.Rmd` files in the [manual tests](https://github.com/correspondMerchant/LAGO-R-Package/tree/main/tests/manual_tests) folder, and read the relevant LAGO papers.
 
 Reach out to [Ante Bing](mailto:abing@bu.edu) or [Minh Bui](mailto:minhb@bu.edu) if you still have questions.
 


### PR DESCRIPTION
document the icc power option, add a grouped example index, and tighten prose

- Document the new icc / power_goal_cluster_id clustering option in the power-goal paragraph, and link the test_icc_power example.
- Add a topic-grouped, clickable index of the runnable manual-test examples.
- Fix two comma splices, remove filler ("Note that", "etc.", "a lot more", etc.), correct "optimal" vs "recommended" where the output is the recommended intervention, fix the 95% render, the TOC label, the Safe Childbirth Checklist name, the launch_duration name mismatch, and function-notation/casing inconsistencies.
- Strip trailing whitespace.