### PR TITLE
Fix single intervention-component crash in the optimizer (#54)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,8 @@ Encoding: UTF-8
 LazyData: true
 Imports: rje, NlcOptim, cli, bslib, shiny, ggplot2, shinyjs
 Suggests:
-    testthat (>= 3.0.0)
+    testthat (>= 3.0.0),
+    tibble
 Config/testthat/edition: 3
 RoxygenNote: 7.3.2
 Depends:

--- a/R/confidence_set_processor.R
+++ b/R/confidence_set_processor.R
@@ -56,7 +56,10 @@ confidence_set_processor <- function(
   }
 
   cs <- get_confidence_set(
-    predictors_data = data[, predictors_list],
+    # drop = FALSE keeps a single predictor as a data.frame; get_confidence_set
+    # indexes predictors_data by column (names(), data[[col]]), which fails if a
+    # one-column selection collapses to a vector.
+    predictors_data = data[, predictors_list, drop = FALSE],
     include_center_effects,
     center_weights_for_outcome_goal,
     include_time_effects,

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -549,7 +549,7 @@ get_confidence_set <- function(
     } else {
       intervention_components
     }
-  )]
+  ), drop = FALSE]
 
   create_cost_function <- function(coeffs) {
     function(x) {

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -166,8 +166,10 @@ get_recommended_interventions <- function(
     } else {
       all_components <- intervention_components
     }
+    # drop = FALSE keeps a one-column selection as a data.frame; without it,
+    # data[, single_col] collapses to a vector and colMeans() errors.
     shrink_to_int_values <- colMeans(
-      data[, all_components],
+      data[, all_components, drop = FALSE],
       na.rm = TRUE
     )
   } else {

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -160,8 +160,10 @@ validate_inputs <- function(
       stop("The 'weights' option must be a numeric vector.")
     }
     # check if the provided weights option has the same length as the number of
-    # observations
-    if (length(weights) != length(data[, intervention_components[1]])) {
+    # observations. Use nrow(data) rather than length(data[, comp]): the latter
+    # returns the observation count for a base data.frame but the column count
+    # for a tibble or a single-column drop, so it mis-validates weights.
+    if (length(weights) != nrow(data)) {
       stop(paste0(
         "The length of the weights must be the same as the ",
         "number of observations in the provided input data."

--- a/tests/testthat/test-optimization.R
+++ b/tests/testthat/test-optimization.R
@@ -147,3 +147,87 @@ test_that("the overall test result is returned (not just printed) when a group c
   )))
   expect_null(res_no_group$test_results)
 })
+
+test_that("a single intervention component does not crash the optimizer (#54)", {
+  # data[, one_col] used to collapse to a vector, breaking colMeans() (shrinking
+  # path) and the confidence-set construction (data[[col]] / apply over rows).
+  # Uses a base data.frame (not a tibble) so the [, ] drop actually triggers.
+  d <- data.frame(
+    dose = rep(0:3, each = 4),
+    y = c(0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1)
+  )
+  base <- list(
+    data = d, outcome_name = "y", outcome_type = "binary",
+    intervention_components = "dose",
+    intervention_lower_bounds = 0, intervention_upper_bounds = 3,
+    cost_list_of_vectors = list(c(0, 1)),
+    outcome_goal_intention = "maximize"
+  )
+
+  # reachable goal -> confidence-set path
+  res_cs <- suppressWarnings(suppressMessages(do.call(
+    lago_optimization,
+    c(base, list(
+      outcome_goal = 0.6, include_confidence_set = TRUE,
+      confidence_set_grid_step_size = 1
+    ))
+  )))
+  expect_length(res_cs$rec_int, 1)
+  expect_true("dose" %in% names(res_cs$cs))
+
+  # unreachable goal -> shrinking path (the colMeans() site)
+  res_shrink <- suppressWarnings(suppressMessages(do.call(
+    lago_optimization,
+    c(base, list(outcome_goal = 0.999, include_confidence_set = FALSE))
+  )))
+  expect_length(res_shrink$rec_int, 1)
+
+  # continuous outcome + CS exercises get_vcov / prepare_design_matrix on
+  # predictors_data, the confidence_set_processor drop = FALSE site that the
+  # binary CS path above does not reach.
+  set.seed(1)
+  dc <- data.frame(x = seq(0, 10, length.out = 30))
+  dc$y <- 1.5 * dc$x + rnorm(30, 0, 1)
+  res_cts <- suppressWarnings(suppressMessages(lago_optimization(
+    data = dc, outcome_name = "y", outcome_type = "continuous",
+    glm_family = "gaussian", link = "identity",
+    intervention_components = "x",
+    intervention_lower_bounds = 0, intervention_upper_bounds = 10,
+    cost_list_of_vectors = list(c(0, 1)),
+    outcome_goal = 12, outcome_goal_intention = "maximize",
+    include_confidence_set = TRUE, confidence_set_grid_step_size = 1
+  )))
+  expect_length(res_cts$rec_int, 1)
+  expect_true("x" %in% names(res_cts$cs))
+})
+
+test_that("weights length is validated against the number of observations, not columns (#54)", {
+  # length(data[, comp]) counted columns for a tibble / single-column drop, so
+  # correctly-sized weights on a single-component tibble were wrongly rejected.
+  tb <- tibble::tibble(
+    dose = rep(0:3, each = 4),
+    y = c(0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1)
+  )
+  base <- list(
+    data = tb, outcome_name = "y", outcome_type = "binary",
+    intervention_components = "dose",
+    intervention_lower_bounds = 0, intervention_upper_bounds = 3,
+    cost_list_of_vectors = list(c(0, 1)),
+    outcome_goal = 0.6, outcome_goal_intention = "maximize",
+    include_confidence_set = FALSE
+  )
+  # correctly-sized weights (one per observation) are accepted
+  expect_length(
+    suppressWarnings(suppressMessages(do.call(
+      lago_optimization, c(base, list(weights = rep(1, nrow(tb))))
+    )))$rec_int,
+    1
+  )
+  # wrong-length weights are still rejected
+  expect_error(
+    suppressWarnings(suppressMessages(do.call(
+      lago_optimization, c(base, list(weights = rep(1, 5)))
+    ))),
+    "number of observations"
+  )
+})

--- a/tests/testthat/test-optimization.R
+++ b/tests/testthat/test-optimization.R
@@ -204,6 +204,7 @@ test_that("a single intervention component does not crash the optimizer (#54)", 
 test_that("weights length is validated against the number of observations, not columns (#54)", {
   # length(data[, comp]) counted columns for a tibble / single-column drop, so
   # correctly-sized weights on a single-component tibble were wrongly rejected.
+  skip_if_not_installed("tibble")
   tb <- tibble::tibble(
     dose = rep(0:3, each = 4),
     y = c(0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1, 1)


### PR DESCRIPTION
A single intervention component made data[, all_components] collapse to a vector, so downstream code that expects a data.frame/matrix crashed: colMeans() on the shrinking path, and the confidence-set construction (names()/data[[col]] in prepare_design_matrix, apply() over the cost table).

Add drop = FALSE at the three single-column selection sites:
- get_recommended_interventions.R (shrinking-path colMeans)
- confidence_set_processor.R (predictors_data)
- get_confidence_set.R (confidence-set cost table)

Also fix the related single-column fragility in the weights-length check: length(data[, intervention_components[1]]) counted observations for a base data.frame but columns for a tibble (or a single-column drop), so correctly-sized weights on a single-component tibble were wrongly rejected. Use nrow(data) instead.

drop = FALSE is a no-op for multi-component runs. Add regression tests covering the shrinking, binary confidence-set, continuous confidence-set (exercises get_vcov), and weights-length paths.