### PR TITLE
Reorganize NEWS as a flat reverse-chronological changelog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,34 +1,37 @@
 # LAGO 1.0.12
 
-## New features
-
-* `lago_optimization()` supports a standalone power goal, an outcome goal, or
-  both together, taking the higher of the outcome goal and the power-implied
-  outcome (#40).
-* Added a power-calculation design-effect adjustment via the `icc` argument, so
-  the power goal can account for within-center clustering (#29).
+* `lago_optimization()` now returns an object of class `"lago"` with `print()`,
+  `summary()`, and `plot()` methods for a readable console summary and a
+  confidence-set plot. The result is still a plain list, so existing `$`-based
+  access is unchanged. (#61)
+* Added an "Optimizing an intervention with LAGO" vignette that walks through a
+  full optimization on the bundled BetterBirth data, rendered as an Articles
+  page on the documentation site. (#61)
+* Added a hex logo and refreshed the README header, badges plus a title logo,
+  and removed the now-redundant banner. (#56, #61)
 * Added a `quiet` argument to `lago_optimization()` that skips the progress
-  messages and their paced delays, making programmatic and repeated calls
-  substantially faster while returning identical results.
-* `lago_optimization()` now returns an object of class `"lago"` with
-  `print()`, `summary()`, and `plot()` methods. The result is still a list, so
-  existing `$`-based access is unchanged.
-* The overall intervention-effect test result is now returned in the result
-  object rather than only printed (#49).
+  messages and their paced delays. Programmatic and repeated calls run
+  substantially faster while returning identical results. (#60)
 * `visualize_cost()` gained a "Copy to clipboard" button, a numeric cost
-  summary, aligned cost and marginal-cost axes, and, on close, returns the cost
-  list to the R session (assigned to `lago_cost_list`).
-* `visualize_cost()` sliders now support per-component custom ranges (#34).
+  summary, and aligned cost and marginal-cost axes. On close it now returns the
+  assembled cost list to the R session, assigned to `lago_cost_list`. (#59)
+* Expanded the reference documentation for the bundled datasets with fuller
+  variable descriptions. (#58)
+* Added a pkgdown documentation site published to GitHub Pages. (#53)
+* Added a GPL-3 `LICENSE` file and polished the README presentation. (#56)
+* Fixed a crash when a single intervention component was used. (#54)
+* Added an `icc` argument to the power calculation that applies a design-effect
+  adjustment, so the power goal can account for within-center clustering. (#29)
+* The overall intervention-effect test result (statistic and p-value) is now
+  returned in the result object rather than only printed. (#49)
+* Added an automated test suite (testthat) and continuous-integration checks.
+  (#45)
+* `visualize_cost()` sliders now support per-component default and custom
+  ranges. (#34)
 * Added non-fatal outcome-model fit diagnostics that warn about a questionable
-  fit while the optimization continues (#36).
+  fit while the optimization continues. (#36)
 * Supplying `optimization_grid_search_step_size` now switches the optimization
-  method to grid search automatically (#32).
-
-## Bug fixes
-
-* Fixed a crash when a single intervention component was used (#54).
-
-## Documentation and infrastructure
-
-* Added a pkgdown documentation site (#53).
-* Added an automated test suite (testthat) and continuous integration (#45).
+  method to grid search automatically. (#32)
+* `lago_optimization()` now accepts a standalone power goal, an outcome goal, or
+  both together, taking the higher of the outcome goal and the power-implied
+  outcome. (#40)


### PR DESCRIPTION
Rewrite NEWS.md as a single newest-first list under the 1.0.12 heading, one to two sentences per change with the PR number, dropping the feature/bugfix/docs subheadings. Backfill entries that shipped without a NEWS line: the optimization vignette, the hex logo and README header refresh (including the banner removal), and the expanded dataset docs.