### PR TITLE
Docs/examples coverage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # LAGO 1.0.12
 
+* Added runnable `@examples` to every exported function that lacked them:
+  `get_confidence_set()` and the `print()`, `summary()`, and `plot()` methods
+  for `"lago"` objects. Every documented function now ships an example.
 * Added `lago_report()`, which renders a self-contained HTML report for a
   `"lago"` result. It knits a bundled R Markdown template that lays out the same
   sections as the console methods plus the confidence-set plot and a session-info

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * Added runnable `@examples` to every exported function that lacked them:
   `get_confidence_set()` and the `print()`, `summary()`, and `plot()` methods
-  for `"lago"` objects. Every documented function now ships an example.
+  for `"lago"` objects. Every exported function now ships an example.
 * Added `lago_report()`, which renders a self-contained HTML report for a
   `"lago"` result. It knits a bundled R Markdown template that lays out the same
   sections as the console methods plus the confidence-set plot and a session-info

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -63,25 +63,40 @@
 #' @importFrom rje expit logit
 #'
 #' @examples
-#' # Normally called through lago_optimization(include_confidence_set = TRUE).
-#' # Called directly, it needs the already-fitted outcome model and the
-#' # recommended intervention from the optimization step.
-#' data(BB_data)
+#' # Normally reached through lago_optimization(include_confidence_set = TRUE).
+#' # Called directly it needs the fitted outcome model and the recommended
+#' # intervention from the optimization step, so both are taken from a run of
+#' # the optimizer rather than refitting the model by hand. Fitting it by hand
+#' # also works, but the model's coefficient order must match the order the
+#' # intervention components and center characteristics are listed in, because
+#' # the prediction matrix is bound to the coefficient vector by position.
+#' # The lower bounds start at 1 while the data also contains 0s, so the
+#' # optimizer warns about that; the warning is expected here.
+#' opt <- lago_optimization(
+#'   data = BB_data,
+#'   outcome_name = "pp3_oxytocin_mother",
+#'   outcome_type = "binary",
+#'   glm_family = "binomial",
+#'   intervention_components = c("coaching_updt", "launch_duration"),
+#'   center_characteristics = c("birth_volume_100"),
+#'   center_characteristics_optimization_values = 1.75,
+#'   intervention_lower_bounds = c(1, 1),
+#'   intervention_upper_bounds = c(40, 5),
+#'   cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+#'   outcome_goal = 0.85,
+#'   outcome_goal_intention = "maximize",
+#'   include_confidence_set = FALSE,
+#'   quiet = TRUE
+#' )
 #'
 #' intervention_components <- c("coaching_updt", "launch_duration")
 #' predictors <- c(intervention_components, "birth_volume_100")
-#'
-#' fitted_model <- glm(
-#'   pp3_oxytocin_mother ~ coaching_updt + launch_duration + birth_volume_100,
-#'   family = binomial(link = "logit"),
-#'   data = BB_data
-#' )
 #'
 #' cs <- get_confidence_set(
 #'   predictors_data = BB_data[, predictors, drop = FALSE],
 #'   intervention_components = intervention_components,
 #'   outcome_data = BB_data$pp3_oxytocin_mother,
-#'   fitted_model = fitted_model,
+#'   fitted_model = opt$model,
 #'   link = "logit",
 #'   outcome_goal = 0.85,
 #'   outcome_type = "binary",
@@ -91,12 +106,18 @@
 #'   center_characteristics = "birth_volume_100",
 #'   center_characteristics_optimization_values = 1.75,
 #'   cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
-#'   rec_int = c(28, 5)
+#'   rec_int = opt$rec_int
 #' )
 #'
-#' # Percentage of the grid inside the 95% confidence set, and the set itself.
+#' # Percentage of the grid inside the 95% confidence set.
 #' cs$confidence_set_size_percentage
-#' head(cs$cs)
+#'
+#' # Row 1 is the recommended intervention, prepended to the grid so its
+#' # confidence interval is computed too; it need not be a grid point, and
+#' # lago_optimization() strips it from the confidence set it returns. Rows 2
+#' # and on are the grid points inside the confidence set.
+#' cs$cs[1, ]
+#' head(cs$cs[-1, ])
 #'
 #' @keywords internal
 #' @export

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -66,10 +66,14 @@
 #' # Normally reached through lago_optimization(include_confidence_set = TRUE).
 #' # Called directly it needs the fitted outcome model and the recommended
 #' # intervention from the optimization step, so both are taken from a run of
-#' # the optimizer rather than refitting the model by hand. Fitting it by hand
-#' # also works, but the model's coefficient order must match the order the
-#' # intervention components and center characteristics are listed in, because
-#' # the prediction matrix is bound to the coefficient vector by position.
+#' # the optimizer rather than refitting the model by hand: get_confidence_set()
+#' # binds its prediction matrix to the coefficient vector by position, so
+#' # passing opt$model is the reliable way to get that order right. A
+#' # hand-fitted model works only if its coefficients are in the order the
+#' # prediction matrix is assembled in: intercept, fixed center effects, fixed
+#' # time effects, intervention components, additional covariates, then center
+#' # characteristics. A wrong number of coefficients errors; a wrong order is
+#' # silent and returns a different confidence set.
 #' # The lower bounds start at 1 while the data also contains 0s, so the
 #' # optimizer warns about that; the warning is expected here.
 #' opt <- lago_optimization(
@@ -109,13 +113,15 @@
 #'   rec_int = opt$rec_int
 #' )
 #'
-#' # Percentage of the grid inside the 95% confidence set.
+#' # Fraction of the grid inside the 95% confidence set. print() shows the
+#' # same number as a percentage.
 #' cs$confidence_set_size_percentage
 #'
-#' # Row 1 is the recommended intervention, prepended to the grid so its
-#' # confidence interval is computed too; it need not be a grid point, and
-#' # lago_optimization() strips it from the confidence set it returns. Rows 2
-#' # and on are the grid points inside the confidence set.
+#' # rec_int is prepended to the grid so its confidence interval is computed
+#' # too, and a recommendation from the optimizer is always inside its own
+#' # confidence set, so row 1 is that recommendation. It need not be a grid
+#' # point, and lago_optimization() strips it from the confidence set it
+#' # returns. Rows 2 and on are the grid points inside the confidence set.
 #' cs$cs[1, ]
 #' head(cs$cs[-1, ])
 #'

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -62,6 +62,42 @@
 #' @import stats
 #' @importFrom rje expit logit
 #'
+#' @examples
+#' # Normally called through lago_optimization(include_confidence_set = TRUE).
+#' # Called directly, it needs the already-fitted outcome model and the
+#' # recommended intervention from the optimization step.
+#' data(BB_data)
+#'
+#' intervention_components <- c("coaching_updt", "launch_duration")
+#' predictors <- c(intervention_components, "birth_volume_100")
+#'
+#' fitted_model <- glm(
+#'   pp3_oxytocin_mother ~ coaching_updt + launch_duration + birth_volume_100,
+#'   family = binomial(link = "logit"),
+#'   data = BB_data
+#' )
+#'
+#' cs <- get_confidence_set(
+#'   predictors_data = BB_data[, predictors, drop = FALSE],
+#'   intervention_components = intervention_components,
+#'   outcome_data = BB_data$pp3_oxytocin_mother,
+#'   fitted_model = fitted_model,
+#'   link = "logit",
+#'   outcome_goal = 0.85,
+#'   outcome_type = "binary",
+#'   intervention_lower_bounds = c(1, 1),
+#'   intervention_upper_bounds = c(40, 5),
+#'   confidence_set_grid_step_size = c(1, 1),
+#'   center_characteristics = "birth_volume_100",
+#'   center_characteristics_optimization_values = 1.75,
+#'   cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+#'   rec_int = c(28, 5)
+#' )
+#'
+#' # Percentage of the grid inside the 95% confidence set, and the set itself.
+#' cs$confidence_set_size_percentage
+#' head(cs$cs)
+#'
 #' @keywords internal
 #' @export
 #'

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -118,10 +118,10 @@
 #' cs$confidence_set_size_percentage
 #'
 #' # rec_int is prepended to the grid so its confidence interval is computed
-#' # too, and a recommendation from the optimizer is always inside its own
-#' # confidence set, so row 1 is that recommendation. It need not be a grid
-#' # point, and lago_optimization() strips it from the confidence set it
-#' # returns. Rows 2 and on are the grid points inside the confidence set.
+#' # too, and row 1 is that prepended row whenever rec_int's own interval
+#' # covers the outcome goal, as it does here. It need not be a grid point,
+#' # and lago_optimization() strips row 1 from the confidence set it returns.
+#' # Rows 2 and on are the grid points inside the confidence set.
 #' cs$cs[1, ]
 #' head(cs$cs[-1, ])
 #'

--- a/R/lago_methods.R
+++ b/R/lago_methods.R
@@ -116,7 +116,8 @@
 #'
 #' @examples
 #' # lago_optimization() already prints the result, so quiet = TRUE avoids
-#' # rendering it twice here.
+#' # rendering it twice here. The lower bounds start at 1 while the data also
+#' # contains 0s, so the optimizer warns about that; the warning is expected.
 #' result <- lago_optimization(
 #'   data = BB_data,
 #'   outcome_name = "pp3_oxytocin_mother",
@@ -156,6 +157,9 @@ print.lago <- function(x, ...) {
 #' @return `object`, invisibly.
 #'
 #' @examples
+#' # summary() currently renders exactly the same output as print(). The lower
+#' # bounds start at 1 while the data also contains 0s, so the optimizer warns
+#' # about that; the warning is expected here.
 #' result <- lago_optimization(
 #'   data = BB_data,
 #'   outcome_name = "pp3_oxytocin_mother",
@@ -197,8 +201,12 @@ summary.lago <- function(object, ...) {
 #' invisibly.
 #'
 #' @examples
-#' # include_confidence_set = TRUE is required: there is nothing to plot
-#' # without a confidence set.
+#' # A plot needs a non-empty confidence set: plot() returns invisibly with a
+#' # message when result$cs is NULL, which can happen even with
+#' # include_confidence_set = TRUE (its default) if no confidence set was found
+#' # for the outcome goal, or if the shrinking method was used.
+#' # The lower bounds start at 1 while the data also contains 0s, so the
+#' # optimizer warns about that; the warning is expected here.
 #' result <- lago_optimization(
 #'   data = BB_data,
 #'   outcome_name = "pp3_oxytocin_mother",

--- a/R/lago_methods.R
+++ b/R/lago_methods.R
@@ -113,6 +113,30 @@
 #' @param ... Ignored.
 #'
 #' @return `x`, invisibly.
+#'
+#' @examples
+#' # lago_optimization() already prints the result, so quiet = TRUE avoids
+#' # rendering it twice here.
+#' result <- lago_optimization(
+#'   data = BB_data,
+#'   outcome_name = "pp3_oxytocin_mother",
+#'   outcome_type = "binary",
+#'   glm_family = "binomial",
+#'   intervention_components = c("coaching_updt", "launch_duration"),
+#'   center_characteristics = c("birth_volume_100"),
+#'   center_characteristics_optimization_values = 1.75,
+#'   intervention_lower_bounds = c(1, 1),
+#'   intervention_upper_bounds = c(40, 5),
+#'   cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+#'   outcome_goal = 0.85,
+#'   outcome_goal_intention = "maximize",
+#'   include_confidence_set = TRUE,
+#'   confidence_set_grid_step_size = c(1, 1),
+#'   quiet = TRUE
+#' )
+#'
+#' print(result)
+#'
 #' @exportS3Method print lago
 print.lago <- function(x, ...) {
   .lago_render(x, full = FALSE)
@@ -130,6 +154,28 @@ print.lago <- function(x, ...) {
 #' @param ... Ignored.
 #'
 #' @return `object`, invisibly.
+#'
+#' @examples
+#' result <- lago_optimization(
+#'   data = BB_data,
+#'   outcome_name = "pp3_oxytocin_mother",
+#'   outcome_type = "binary",
+#'   glm_family = "binomial",
+#'   intervention_components = c("coaching_updt", "launch_duration"),
+#'   center_characteristics = c("birth_volume_100"),
+#'   center_characteristics_optimization_values = 1.75,
+#'   intervention_lower_bounds = c(1, 1),
+#'   intervention_upper_bounds = c(40, 5),
+#'   cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+#'   outcome_goal = 0.85,
+#'   outcome_goal_intention = "maximize",
+#'   include_confidence_set = TRUE,
+#'   confidence_set_grid_step_size = c(1, 1),
+#'   quiet = TRUE
+#' )
+#'
+#' summary(result)
+#'
 #' @exportS3Method summary lago
 summary.lago <- function(object, ...) {
   .lago_render(object, full = TRUE)
@@ -149,6 +195,32 @@ summary.lago <- function(object, ...) {
 #'
 #' @return A ggplot object (invisibly) when a plot is produced, otherwise `NULL`
 #' invisibly.
+#'
+#' @examples
+#' # include_confidence_set = TRUE is required: there is nothing to plot
+#' # without a confidence set.
+#' result <- lago_optimization(
+#'   data = BB_data,
+#'   outcome_name = "pp3_oxytocin_mother",
+#'   outcome_type = "binary",
+#'   glm_family = "binomial",
+#'   intervention_components = c("coaching_updt", "launch_duration"),
+#'   center_characteristics = c("birth_volume_100"),
+#'   center_characteristics_optimization_values = 1.75,
+#'   intervention_lower_bounds = c(1, 1),
+#'   intervention_upper_bounds = c(40, 5),
+#'   cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+#'   outcome_goal = 0.85,
+#'   outcome_goal_intention = "maximize",
+#'   include_confidence_set = TRUE,
+#'   confidence_set_grid_step_size = c(1, 1),
+#'   quiet = TRUE
+#' )
+#'
+#' # Two components: the confidence set grid with the recommended
+#' # intervention marked.
+#' plot(result)
+#'
 #' @importFrom ggplot2 .data
 #' @exportS3Method plot lago
 plot.lago <- function(x, ...) {

--- a/R/lago_methods.R
+++ b/R/lago_methods.R
@@ -104,8 +104,8 @@
 #' sections: an inputs recap (data dimensions, outcome, intervention components,
 #' model family/link and fixed effects, goals, costs and bounds), the fitted
 #' outcome-model coefficient table, the overall intervention-effect test, the
-#' recommended intervention with its cost and the estimated outcome (and its 95%
-#' confidence interval), and the confidence set (size, cost IQR, and first
+#' recommended intervention with its cost and the estimated outcome (and its
+#' 95\% confidence interval), and the confidence set (size, cost IQR, and first
 #' rows). Everything is shown on the console so results can be read without
 #' further calls. [summary.lago()] renders the same output.
 #'
@@ -187,12 +187,14 @@ summary.lago <- function(object, ...) {
 
 #' Plot a LAGO optimization result
 #'
-#' @description Visualizes the 95% confidence set. For a two-component
+#' @description Visualizes the 95\% confidence set. For a two-component
 #' intervention it plots the grid points in the confidence set with the
 #' recommended intervention highlighted; for a single component it plots the
-#' confidence interval bounds against the dose. Requires a confidence set
-#' (`include_confidence_set = TRUE` in [lago_optimization()]); otherwise it
-#' returns invisibly with a message rather than erroring.
+#' confidence interval bounds against the dose. A non-empty confidence set is
+#' required. `result$cs` can be NULL even with `include_confidence_set = TRUE`
+#' (its default), when no confidence set was found for the outcome goal or the
+#' shrinking method was used, and then plot() returns invisibly with a message
+#' rather than erroring.
 #'
 #' @param x A "lago" object returned by [lago_optimization()].
 #' @param ... Ignored.

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -220,8 +220,8 @@
 #' recommended interventions,
 #' associated cost for the interventions,
 #' estimated outcome mean/probability for the intervention group,
-#' 95% confidence set percentage,
-#' 95% confidence set,
+#' 95\% confidence set percentage,
+#' 95\% confidence set,
 #' overall intervention test results (test_results), a list with the test
 #' statistic and p-value; NULL unless a valid 'group' column is supplied.
 #' The confidence set fields are only present when include_confidence_set = TRUE.)

--- a/R/lago_report.R
+++ b/R/lago_report.R
@@ -4,7 +4,7 @@
 #' [lago_optimization()]. The report knits a bundled parameterized R Markdown
 #' template and lays out the same sections, in the same order and with the same
 #' labels, as the console methods ([print.lago()] / [summary.lago()]): the
-#' recommended intervention, its cost, the estimated outcome (with its 95% CI)
+#' recommended intervention, its cost, the estimated outcome (with its 95\% CI)
 #' and goal, the power goal (when present), the confidence set (size, cost IQR,
 #' and first rows), the overall intervention-effect test (when present), the
 #' fitted outcome-model coefficient table, and the confidence-set plot from

--- a/man/get_confidence_set.Rd
+++ b/man/get_confidence_set.Rd
@@ -113,25 +113,40 @@ Internal function that calculates the confidence set
 for the recommended interventions
 }
 \examples{
-# Normally called through lago_optimization(include_confidence_set = TRUE).
-# Called directly, it needs the already-fitted outcome model and the
-# recommended intervention from the optimization step.
-data(BB_data)
+# Normally reached through lago_optimization(include_confidence_set = TRUE).
+# Called directly it needs the fitted outcome model and the recommended
+# intervention from the optimization step, so both are taken from a run of
+# the optimizer rather than refitting the model by hand. Fitting it by hand
+# also works, but the model's coefficient order must match the order the
+# intervention components and center characteristics are listed in, because
+# the prediction matrix is bound to the coefficient vector by position.
+# The lower bounds start at 1 while the data also contains 0s, so the
+# optimizer warns about that; the warning is expected here.
+opt <- lago_optimization(
+  data = BB_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  glm_family = "binomial",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  outcome_goal = 0.85,
+  outcome_goal_intention = "maximize",
+  include_confidence_set = FALSE,
+  quiet = TRUE
+)
 
 intervention_components <- c("coaching_updt", "launch_duration")
 predictors <- c(intervention_components, "birth_volume_100")
-
-fitted_model <- glm(
-  pp3_oxytocin_mother ~ coaching_updt + launch_duration + birth_volume_100,
-  family = binomial(link = "logit"),
-  data = BB_data
-)
 
 cs <- get_confidence_set(
   predictors_data = BB_data[, predictors, drop = FALSE],
   intervention_components = intervention_components,
   outcome_data = BB_data$pp3_oxytocin_mother,
-  fitted_model = fitted_model,
+  fitted_model = opt$model,
   link = "logit",
   outcome_goal = 0.85,
   outcome_type = "binary",
@@ -141,12 +156,18 @@ cs <- get_confidence_set(
   center_characteristics = "birth_volume_100",
   center_characteristics_optimization_values = 1.75,
   cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
-  rec_int = c(28, 5)
+  rec_int = opt$rec_int
 )
 
-# Percentage of the grid inside the 95\% confidence set, and the set itself.
+# Percentage of the grid inside the 95\% confidence set.
 cs$confidence_set_size_percentage
-head(cs$cs)
+
+# Row 1 is the recommended intervention, prepended to the grid so its
+# confidence interval is computed too; it need not be a grid point, and
+# lago_optimization() strips it from the confidence set it returns. Rows 2
+# and on are the grid points inside the confidence set.
+cs$cs[1, ]
+head(cs$cs[-1, ])
 
 }
 \keyword{internal}

--- a/man/get_confidence_set.Rd
+++ b/man/get_confidence_set.Rd
@@ -112,4 +112,41 @@ List(
 Internal function that calculates the confidence set
 for the recommended interventions
 }
+\examples{
+# Normally called through lago_optimization(include_confidence_set = TRUE).
+# Called directly, it needs the already-fitted outcome model and the
+# recommended intervention from the optimization step.
+data(BB_data)
+
+intervention_components <- c("coaching_updt", "launch_duration")
+predictors <- c(intervention_components, "birth_volume_100")
+
+fitted_model <- glm(
+  pp3_oxytocin_mother ~ coaching_updt + launch_duration + birth_volume_100,
+  family = binomial(link = "logit"),
+  data = BB_data
+)
+
+cs <- get_confidence_set(
+  predictors_data = BB_data[, predictors, drop = FALSE],
+  intervention_components = intervention_components,
+  outcome_data = BB_data$pp3_oxytocin_mother,
+  fitted_model = fitted_model,
+  link = "logit",
+  outcome_goal = 0.85,
+  outcome_type = "binary",
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  confidence_set_grid_step_size = c(1, 1),
+  center_characteristics = "birth_volume_100",
+  center_characteristics_optimization_values = 1.75,
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  rec_int = c(28, 5)
+)
+
+# Percentage of the grid inside the 95\% confidence set, and the set itself.
+cs$confidence_set_size_percentage
+head(cs$cs)
+
+}
 \keyword{internal}

--- a/man/get_confidence_set.Rd
+++ b/man/get_confidence_set.Rd
@@ -168,10 +168,10 @@ cs <- get_confidence_set(
 cs$confidence_set_size_percentage
 
 # rec_int is prepended to the grid so its confidence interval is computed
-# too, and a recommendation from the optimizer is always inside its own
-# confidence set, so row 1 is that recommendation. It need not be a grid
-# point, and lago_optimization() strips it from the confidence set it
-# returns. Rows 2 and on are the grid points inside the confidence set.
+# too, and row 1 is that prepended row whenever rec_int's own interval
+# covers the outcome goal, as it does here. It need not be a grid point,
+# and lago_optimization() strips row 1 from the confidence set it returns.
+# Rows 2 and on are the grid points inside the confidence set.
 cs$cs[1, ]
 head(cs$cs[-1, ])
 

--- a/man/get_confidence_set.Rd
+++ b/man/get_confidence_set.Rd
@@ -116,10 +116,14 @@ for the recommended interventions
 # Normally reached through lago_optimization(include_confidence_set = TRUE).
 # Called directly it needs the fitted outcome model and the recommended
 # intervention from the optimization step, so both are taken from a run of
-# the optimizer rather than refitting the model by hand. Fitting it by hand
-# also works, but the model's coefficient order must match the order the
-# intervention components and center characteristics are listed in, because
-# the prediction matrix is bound to the coefficient vector by position.
+# the optimizer rather than refitting the model by hand: get_confidence_set()
+# binds its prediction matrix to the coefficient vector by position, so
+# passing opt$model is the reliable way to get that order right. A
+# hand-fitted model works only if its coefficients are in the order the
+# prediction matrix is assembled in: intercept, fixed center effects, fixed
+# time effects, intervention components, additional covariates, then center
+# characteristics. A wrong number of coefficients errors; a wrong order is
+# silent and returns a different confidence set.
 # The lower bounds start at 1 while the data also contains 0s, so the
 # optimizer warns about that; the warning is expected here.
 opt <- lago_optimization(
@@ -159,13 +163,15 @@ cs <- get_confidence_set(
   rec_int = opt$rec_int
 )
 
-# Percentage of the grid inside the 95\% confidence set.
+# Fraction of the grid inside the 95\% confidence set. print() shows the
+# same number as a percentage.
 cs$confidence_set_size_percentage
 
-# Row 1 is the recommended intervention, prepended to the grid so its
-# confidence interval is computed too; it need not be a grid point, and
-# lago_optimization() strips it from the confidence set it returns. Rows 2
-# and on are the grid points inside the confidence set.
+# rec_int is prepended to the grid so its confidence interval is computed
+# too, and a recommendation from the optimizer is always inside its own
+# confidence set, so row 1 is that recommendation. It need not be a grid
+# point, and lago_optimization() strips it from the confidence set it
+# returns. Rows 2 and on are the grid points inside the confidence set.
 cs$cs[1, ]
 head(cs$cs[-1, ])
 

--- a/man/lago_optimization.Rd
+++ b/man/lago_optimization.Rd
@@ -300,8 +300,8 @@ List(
 recommended interventions,
 associated cost for the interventions,
 estimated outcome mean/probability for the intervention group,
-95% confidence set percentage,
-95% confidence set,
+95\% confidence set percentage,
+95\% confidence set,
 overall intervention test results (test_results), a list with the test
 statistic and p-value; NULL unless a valid 'group' column is supplied.
 The confidence set fields are only present when include_confidence_set = TRUE.)

--- a/man/lago_report.Rd
+++ b/man/lago_report.Rd
@@ -34,7 +34,7 @@ Renders a self-contained HTML report for the object returned by
 [lago_optimization()]. The report knits a bundled parameterized R Markdown
 template and lays out the same sections, in the same order and with the same
 labels, as the console methods ([print.lago()] / [summary.lago()]): the
-recommended intervention, its cost, the estimated outcome (with its 95% CI)
+recommended intervention, its cost, the estimated outcome (with its 95\% CI)
 and goal, the power goal (when present), the confidence set (size, cost IQR,
 and first rows), the overall intervention-effect test (when present), the
 fitted outcome-model coefficient table, and the confidence-set plot from

--- a/man/plot.lago.Rd
+++ b/man/plot.lago.Rd
@@ -23,3 +23,29 @@ confidence interval bounds against the dose. Requires a confidence set
 (`include_confidence_set = TRUE` in [lago_optimization()]); otherwise it
 returns invisibly with a message rather than erroring.
 }
+\examples{
+# include_confidence_set = TRUE is required: there is nothing to plot
+# without a confidence set.
+result <- lago_optimization(
+  data = BB_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  glm_family = "binomial",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  outcome_goal = 0.85,
+  outcome_goal_intention = "maximize",
+  include_confidence_set = TRUE,
+  confidence_set_grid_step_size = c(1, 1),
+  quiet = TRUE
+)
+
+# Two components: the confidence set grid with the recommended
+# intervention marked.
+plot(result)
+
+}

--- a/man/plot.lago.Rd
+++ b/man/plot.lago.Rd
@@ -16,12 +16,14 @@ A ggplot object (invisibly) when a plot is produced, otherwise `NULL`
 invisibly.
 }
 \description{
-Visualizes the 95% confidence set. For a two-component
+Visualizes the 95\% confidence set. For a two-component
 intervention it plots the grid points in the confidence set with the
 recommended intervention highlighted; for a single component it plots the
-confidence interval bounds against the dose. Requires a confidence set
-(`include_confidence_set = TRUE` in [lago_optimization()]); otherwise it
-returns invisibly with a message rather than erroring.
+confidence interval bounds against the dose. A non-empty confidence set is
+required. `result$cs` can be NULL even with `include_confidence_set = TRUE`
+(its default), when no confidence set was found for the outcome goal or the
+shrinking method was used, and then plot() returns invisibly with a message
+rather than erroring.
 }
 \examples{
 # A plot needs a non-empty confidence set: plot() returns invisibly with a

--- a/man/plot.lago.Rd
+++ b/man/plot.lago.Rd
@@ -24,8 +24,12 @@ confidence interval bounds against the dose. Requires a confidence set
 returns invisibly with a message rather than erroring.
 }
 \examples{
-# include_confidence_set = TRUE is required: there is nothing to plot
-# without a confidence set.
+# A plot needs a non-empty confidence set: plot() returns invisibly with a
+# message when result$cs is NULL, which can happen even with
+# include_confidence_set = TRUE (its default) if no confidence set was found
+# for the outcome goal, or if the shrinking method was used.
+# The lower bounds start at 1 while the data also contains 0s, so the
+# optimizer warns about that; the warning is expected here.
 result <- lago_optimization(
   data = BB_data,
   outcome_name = "pp3_oxytocin_mother",

--- a/man/print.lago.Rd
+++ b/man/print.lago.Rd
@@ -25,3 +25,27 @@ confidence interval), and the confidence set (size, cost IQR, and first
 rows). Everything is shown on the console so results can be read without
 further calls. [summary.lago()] renders the same output.
 }
+\examples{
+# lago_optimization() already prints the result, so quiet = TRUE avoids
+# rendering it twice here.
+result <- lago_optimization(
+  data = BB_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  glm_family = "binomial",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  outcome_goal = 0.85,
+  outcome_goal_intention = "maximize",
+  include_confidence_set = TRUE,
+  confidence_set_grid_step_size = c(1, 1),
+  quiet = TRUE
+)
+
+print(result)
+
+}

--- a/man/print.lago.Rd
+++ b/man/print.lago.Rd
@@ -20,8 +20,8 @@ Full console display of the object returned by
 sections: an inputs recap (data dimensions, outcome, intervention components,
 model family/link and fixed effects, goals, costs and bounds), the fitted
 outcome-model coefficient table, the overall intervention-effect test, the
-recommended intervention with its cost and the estimated outcome (and its 95%
-confidence interval), and the confidence set (size, cost IQR, and first
+recommended intervention with its cost and the estimated outcome (and its
+95\% confidence interval), and the confidence set (size, cost IQR, and first
 rows). Everything is shown on the console so results can be read without
 further calls. [summary.lago()] renders the same output.
 }

--- a/man/print.lago.Rd
+++ b/man/print.lago.Rd
@@ -27,7 +27,8 @@ further calls. [summary.lago()] renders the same output.
 }
 \examples{
 # lago_optimization() already prints the result, so quiet = TRUE avoids
-# rendering it twice here.
+# rendering it twice here. The lower bounds start at 1 while the data also
+# contains 0s, so the optimizer warns about that; the warning is expected.
 result <- lago_optimization(
   data = BB_data,
   outcome_name = "pp3_oxytocin_mother",

--- a/man/summary.lago.Rd
+++ b/man/summary.lago.Rd
@@ -21,3 +21,25 @@ test, recommended intervention (with cost and the estimated-outcome CI), and
 the confidence set. Provided so `summary()` works as expected on a "lago"
 object.
 }
+\examples{
+result <- lago_optimization(
+  data = BB_data,
+  outcome_name = "pp3_oxytocin_mother",
+  outcome_type = "binary",
+  glm_family = "binomial",
+  intervention_components = c("coaching_updt", "launch_duration"),
+  center_characteristics = c("birth_volume_100"),
+  center_characteristics_optimization_values = 1.75,
+  intervention_lower_bounds = c(1, 1),
+  intervention_upper_bounds = c(40, 5),
+  cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+  outcome_goal = 0.85,
+  outcome_goal_intention = "maximize",
+  include_confidence_set = TRUE,
+  confidence_set_grid_step_size = c(1, 1),
+  quiet = TRUE
+)
+
+summary(result)
+
+}

--- a/man/summary.lago.Rd
+++ b/man/summary.lago.Rd
@@ -22,6 +22,9 @@ the confidence set. Provided so `summary()` works as expected on a "lago"
 object.
 }
 \examples{
+# summary() currently renders exactly the same output as print(). The lower
+# bounds start at 1 while the data also contains 0s, so the optimizer warns
+# about that; the warning is expected here.
 result <- lago_optimization(
   data = BB_data,
   outcome_name = "pp3_oxytocin_mother",


### PR DESCRIPTION
## Add examples to the remaining exported functions

  Every exported function now ships a runnable `@examples` block. Four lacked
  one: `get_confidence_set()` and the `print()`, `summary()` and `plot()`
  methods for `"lago"` objects.

  Zero executable lines change. The whole diff in `R/` is roxygen comment
  lines, plus the regenerated `man/` pages.