### PR TITLE
Fix/confidence set row1 and coef order

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,7 +42,11 @@
   for those configurations, and the corrected values are what the fixes above
   produce. Where the recommended intervention's interval covers the goal and
   at least one grid intervention qualifies, which is the common case, every
-  reported number is unchanged.
+  reported number is unchanged. The estimated-outcome interval additionally
+  changes for most runs that include fixed time effects, since it was computed
+  at the last period rather than the requested one, and the recommended
+  intervention itself changes where a covariate's name was being read as a
+  fixed effect.
 * Fixed the prediction matrix in `get_confidence_set()` being paired with the
   outcome-model coefficients by position. Its columns were relabelled with the
   coefficient names rather than reordered to them, so a model whose terms were
@@ -85,10 +89,11 @@
 * Fixed the confidence set changing when the rows of `data` were reordered.
   The variance-covariance matrix built for continuous outcomes enumerated
   factor levels in order of first appearance while the model orders them by
-  level, so the two were misaligned whenever the data was not already sorted
-  by the factor, and the standard errors were wrong. The matrix is now built
-  with the model's own level order and paired with the prediction matrix by
-  name. The columns of `predictors_data` may also be supplied in any order.
+  level, so the two were misaligned whenever a factor's levels first appeared
+  in an order other than their level order, and the standard errors were then
+  wrong. The matrix is now built with the model's own level order and paired
+  with the prediction matrix by name. The columns of `predictors_data` may
+  also be supplied in any order.
 * Fixed passing more than one center characteristic, which either failed or
   silently added a single recycled column of values to the confidence set
   instead of one column per characteristic.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,61 @@
 # LAGO 1.0.12
 
+* Fixed the 95% confidence interval reported for the estimated outcome.
+  `get_confidence_set()` prepends the recommended intervention to the
+  confidence-set grid so that its interval is computed alongside the grid
+  interventions, and the interval was then picked out of the result by
+  position, as its first row. That row holds the recommended intervention only
+  when its own interval covers the outcome goal, so whenever it did not,
+  `$est_outcome_ci` reported the interval of an ordinary grid intervention
+  instead. The interval is now always the one computed at the recommended
+  intervention, and it is also reported when no grid intervention qualifies,
+  where it used to be suppressed even though it was perfectly well defined.
+* Fixed the confidence set losing one of its members. The prepended
+  recommended intervention was removed from the returned set by position
+  rather than by identity, so whenever the recommended intervention was not
+  itself in the set, a genuine qualifying grid intervention was deleted in its
+  place.
+* Fixed `confidence_set_size_percentage`, which understated the size of the
+  confidence set. It subtracted the prepended recommended intervention from
+  both the count of qualifying interventions and the size of the grid
+  unconditionally, including when that intervention had never been counted.
+  The numerator and the denominator now both count grid interventions only.
+* A confidence set containing exactly one grid intervention is no longer
+  discarded and reported as empty with a size of 0.
+* Fixed the confidence-interval bounds being attached to the wrong grid
+  interventions. When the interval of a grid intervention could not be
+  computed, the bounds of every later intervention in the confidence set were
+  shifted relative to the coordinates they were reported against. This is
+  reachable with two-way clustering, where the variance estimator is not
+  guaranteed to be positive semi-definite and some intervals come out
+  undefined.
+* `get_confidence_set()` now returns a third field, `rec_int_ci`, the interval
+  at the recommended intervention as a named `c(lower, upper)`, computed
+  whether or not it covers the outcome goal, and `$cs` holds the qualifying
+  grid interventions only. Its return shape has therefore changed for code
+  that calls `get_confidence_set()` directly. The fields on the result of
+  `lago_optimization()` keep the names and shapes they had.
+* The confidence set, its size, and the estimated-outcome confidence interval
+  can differ from earlier releases for configurations where the recommended
+  intervention's own interval does not cover the outcome goal, or where no
+  grid intervention qualifies. The values reported before were the wrong ones
+  for those configurations, and the corrected values are what the fixes above
+  produce. Where the recommended intervention's interval covers the goal and
+  at least one grid intervention qualifies, which is the common case, every
+  reported number is unchanged.
+* Fixed the prediction matrix in `get_confidence_set()` being paired with the
+  outcome-model coefficients by position. Its columns were relabelled with the
+  coefficient names rather than reordered to them, so a model whose terms were
+  fitted in an order other than the order the matrix is assembled in had every
+  column multiplied by the wrong coefficient, silently returning a different
+  confidence set. The coefficients are now matched to the columns by name, so
+  the order of the model's terms no longer matters, and a model that genuinely
+  does not correspond to the predictors raises an error naming the
+  coefficients and the predictors that failed to match instead of returning a
+  plausible-looking answer. An additional covariate whose own name begins with
+  "period" is also no longer counted as a fixed time effect, which used to make
+  the prediction matrix one column too wide and fail with "non-conformable
+  arguments".
 * Added runnable `@examples` to every exported function that lacked them:
   `get_confidence_set()` and the `print()`, `summary()`, and `plot()` methods
   for `"lago"` objects. Every exported function now ships an example.

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,11 +66,12 @@
   none, and the empty result collapsed the center-level effects to nothing.
   Periods are now resolved against the levels the model was fitted on.
 * Fixed the interval for the estimated outcome being computed at the last time
-  period while the estimate itself used the requested one. The two described
-  different periods, far enough apart that the reported interval could exclude
-  the estimate printed beside it. The interval now follows the requested
-  period, so a recommendation reported for one period is no longer given
-  another period's interval.
+  period while the estimate itself used the requested one, so a recommendation
+  reported for one period was given another period's interval. The interval now
+  follows the requested period. This was largely masked before, because the
+  interval was suppressed whenever no grid intervention qualified; now that it
+  is always reported, an interval far enough from the estimate to exclude it
+  would have become visible.
 * Fixed an additional covariate or center characteristic whose name contains
   "center" being counted as a fixed center effect. The recommended
   intervention itself was corrupted through silent vector recycling, so the

--- a/NEWS.md
+++ b/NEWS.md
@@ -56,6 +56,42 @@
   "period" is also no longer counted as a fixed time effect, which used to make
   the prediction matrix one column too wide and fail with "non-conformable
   arguments".
+* Fixed the estimated outcome being reported as 0 whenever a fixed time effect
+  was included and the optimization asked for the reference period. The period
+  was looked up among the model's coefficients, where the reference period has
+  none, and the empty result collapsed the center-level effects to nothing.
+  Periods are now resolved against the levels the model was fitted on.
+* Fixed the interval for the estimated outcome being computed at the last time
+  period while the estimate itself used the requested one. The two described
+  different periods, far enough apart that the reported interval could exclude
+  the estimate printed beside it. The interval now follows the requested
+  period, so a recommendation reported for one period is no longer given
+  another period's interval.
+* Fixed an additional covariate or center characteristic whose name contains
+  "center" being counted as a fixed center effect. The recommended
+  intervention itself was corrupted through silent vector recycling, so the
+  optimizer could report an intervention whose estimated outcome was not the
+  one shown. Model terms are now resolved through the fitted model's own
+  term-to-coefficient mapping rather than by matching names.
+* Fixed a factor or character additional covariate or center characteristic
+  raising an error or being paired with the wrong coefficient. The outcome
+  model names such a coefficient after the factor level, not the column, so
+  looking the column name up among the coefficients found nothing. A factor
+  covariate is now held at its reference level, matching how numeric
+  covariates are held at 0. More than one center characteristic per factor
+  cannot be resolved this way, because exactly one optimization value is
+  allowed per characteristic, and that combination now raises rather than
+  choosing a level silently.
+* Fixed the confidence set changing when the rows of `data` were reordered.
+  The variance-covariance matrix built for continuous outcomes enumerated
+  factor levels in order of first appearance while the model orders them by
+  level, so the two were misaligned whenever the data was not already sorted
+  by the factor, and the standard errors were wrong. The matrix is now built
+  with the model's own level order and paired with the prediction matrix by
+  name. The columns of `predictors_data` may also be supplied in any order.
+* Fixed passing more than one center characteristic, which either failed or
+  silently added a single recycled column of values to the confidence set
+  instead of one column per characteristic.
 * Added runnable `@examples` to every exported function that lacked them:
   `get_confidence_set()` and the `print()`, `summary()`, and `plot()` methods
   for `"lago"` objects. Every exported function now ships an example.

--- a/R/confidence_set_processor.R
+++ b/R/confidence_set_processor.R
@@ -4,6 +4,7 @@ confidence_set_processor <- function(
     step_size_results,
     include_center_effects,
     include_time_effects,
+    time_effect_optimization_value = NULL,
     intervention_components,
     additional_covariates,
     center_characteristics,
@@ -63,13 +64,20 @@ confidence_set_processor <- function(
     # indexes predictors_data by column (names(), data[[col]]), which fails if a
     # one-column selection collapses to a vector.
     predictors_data = data[, predictors_list, drop = FALSE],
-    include_center_effects,
-    center_weights_for_outcome_goal,
-    include_time_effects,
-    additional_covariates,
-    intervention_components,
-    include_interaction_terms,
-    main_components,
+    # every argument is named: get_confidence_set() takes more of them than it
+    # used to, so positional matching would silently pass each one to the
+    # argument that now sits in its place
+    include_center_effects = include_center_effects,
+    center_weights_for_outcome_goal = center_weights_for_outcome_goal,
+    include_time_effects = include_time_effects,
+    # the confidence set is computed at the same period the recommended
+    # intervention and the reported estimated outcome are, so the reported
+    # interval and point estimate refer to the same quantity
+    time_effect_optimization_value = time_effect_optimization_value,
+    additional_covariates = additional_covariates,
+    intervention_components = intervention_components,
+    include_interaction_terms = include_interaction_terms,
+    main_components = main_components,
     outcome_data = data[, outcome_name],
     fitted_model = model,
     link = family_object$link,
@@ -83,7 +91,7 @@ confidence_set_processor <- function(
       center_characteristics_optimization_values,
     confidence_set_alpha = confidence_set_alpha,
     cluster_id = cluster_id,
-    cost_list_of_vectors,
+    cost_list_of_vectors = cost_list_of_vectors,
     rec_int = rec_int
   )
 

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -55,8 +55,18 @@
 #' from the optimization step.
 #'
 #' @return List(
-#'   confidence_set_size_percentage = <number>,
-#'   cs = <data.frame of interventions in the confidence set>
+#'   confidence_set_size_percentage = <number, the size of the confidence set
+#'     as a fraction of the grid. Both the count of qualifying interventions
+#'     and the size of the grid count grid interventions only, so rec_int is
+#'     excluded from each>,
+#'   rec_int_ci = <named numeric c(lower, upper) rounded to 3 decimal places,
+#'     the confidence interval at rec_int. Computed whether or not it covers
+#'     the outcome goal, so callers never have to look for rec_int inside cs.
+#'     NULL when that interval is not computable>,
+#'   cs = <data.frame of the grid interventions whose confidence interval
+#'     covers the outcome goal, with their interval bounds and cost. rec_int is
+#'     never one of its rows, and need not be a grid intervention at all.
+#'     NULL when no grid intervention qualifies>
 #' )
 #'
 #' @import stats
@@ -66,14 +76,13 @@
 #' # Normally reached through lago_optimization(include_confidence_set = TRUE).
 #' # Called directly it needs the fitted outcome model and the recommended
 #' # intervention from the optimization step, so both are taken from a run of
-#' # the optimizer rather than refitting the model by hand: get_confidence_set()
-#' # binds its prediction matrix to the coefficient vector by position, so
-#' # passing opt$model is the reliable way to get that order right. A
-#' # hand-fitted model works only if its coefficients are in the order the
-#' # prediction matrix is assembled in: intercept, fixed center effects, fixed
-#' # time effects, intervention components, additional covariates, then center
-#' # characteristics. A wrong number of coefficients errors; a wrong order is
-#' # silent and returns a different confidence set.
+#' # the optimizer rather than refitting the model by hand. get_confidence_set()
+#' # binds its prediction matrix to the coefficient vector by name, so a
+#' # hand-fitted model may list its terms in any order. It must be fitted on
+#' # exactly the predictors passed here, though: the intercept, the fixed
+#' # center effects, the fixed time effects, the intervention components, the
+#' # additional covariates and the center characteristics. Any other set of
+#' # coefficients is an error naming what did not match.
 #' # The lower bounds start at 1 while the data also contains 0s, so the
 #' # optimizer warns about that; the warning is expected here.
 #' opt <- lago_optimization(
@@ -113,17 +122,23 @@
 #'   rec_int = opt$rec_int
 #' )
 #'
-#' # Fraction of the grid inside the 95% confidence set. print() shows the
-#' # same number as a percentage.
+#' # Fraction of the grid inside the 95% confidence set: 18 of the 200 grid
+#' # interventions qualify here (40 coaching values by 5 launch durations), so
+#' # 0.09. print() shows the same number as a percentage.
 #' cs$confidence_set_size_percentage
 #'
-#' # rec_int is prepended to the grid so its confidence interval is computed
-#' # too, and row 1 is that prepended row whenever rec_int's own interval
-#' # covers the outcome goal, as it does here. It need not be a grid point,
-#' # and lago_optimization() strips row 1 from the confidence set it returns.
-#' # Rows 2 and on are the grid points inside the confidence set.
-#' cs$cs[1, ]
-#' head(cs$cs[-1, ])
+#' # The confidence interval at the recommended intervention, reported in its
+#' # own field as c(lower, upper). It is computed whether or not it covers the
+#' # outcome goal, so it is available even when no grid intervention qualifies.
+#' # lago_optimization() reports this interval as $est_outcome_ci.
+#' cs$rec_int_ci
+#'
+#' # rec_int need not be one of the grid interventions, and here it is not:
+#' # its launch_duration is about 2.78 while the grid steps through whole
+#' # days. It is never a row of cs either, which holds the 18 qualifying grid
+#' # interventions and nothing else.
+#' opt$rec_int
+#' head(cs$cs)
 #'
 #' @keywords internal
 #' @export
@@ -163,8 +178,14 @@ get_confidence_set <- function(
   }
   # expand grid
   grid_x <- expand.grid(sequences)
+  # the number of grid interventions, before the recommended intervention is
+  # prepended. The confidence set and its size are reported over these
+  # interventions only, so this is the denominator of the percentage.
+  n_grid_rows <- nrow(grid_x)
   # add the rec_int values to the grid so that
-  # the CI can be calculated for the recommended interventions
+  # the CI can be calculated for the recommended interventions.
+  # rec_int is row 1 from here on, and the grid interventions are rows
+  # 2 to n_rows. rec_int need not be one of the grid interventions.
   grid_x <- rbind(rec_int, grid_x)
   n_rows <- nrow(grid_x)
 
@@ -209,6 +230,31 @@ get_confidence_set <- function(
     new_grid <- grid_x
   }
 
+  # the coefficient names glm gave the fixed-effect dummy columns. Every name
+  # the assembly below can supply for itself is set aside first, so a covariate
+  # whose own name begins with "center" or "period" is not mistaken for a
+  # dummy. glm expands a factor into one dummy per non-reference level, in
+  # level order, which is also the order the dummy columns are built in below.
+  named_predictors <- gsub("`", "", c(
+    "(Intercept)", intervention_components, additional_covariates,
+    center_characteristics
+  ))
+  fixed_effect_coefs <- names(coef(fitted_model))[
+    !gsub("`", "", names(coef(fitted_model))) %in% named_predictors
+  ]
+
+  # the names the assembled columns of one block carry. A block whose width and
+  # number of coefficient names disagree cannot be matched at all, so it is
+  # named unmatchably and reported by the coefficient check below instead of
+  # failing here.
+  block_names <- function(coef_names, n_cols, label) {
+    if (length(coef_names) == n_cols) {
+      coef_names
+    } else {
+      paste0(label, seq_len(n_cols))
+    }
+  }
+
   # add center effects (if specified) to the data that
   # will be used for predictions
   if (include_center_effects) {
@@ -223,14 +269,25 @@ get_confidence_set <- function(
       ncol = n_centers,
       byrow = TRUE
     )
+    # center_weights_for_outcome_goal is in center level order, so column i
+    # above is the i-th non-reference center, which is the i-th center dummy.
+    center_effect_names <- block_names(
+      grep("^center", fixed_effect_coefs, value = TRUE, ignore.case = TRUE),
+      n_centers,
+      "unmatched center effect "
+    )
   }
 
   # add time effects (if specified) to the data that
   # will be used for predictions
   if (include_time_effects) {
-    n_periods <- length(
-      grep("period", names(coef(fitted_model)), ignore.case = TRUE)
+    # one column per time dummy, in period level order, so the last column is
+    # the last period, which is the one set to 1 below
+    time_effect_names <- grep(
+      "^period", fixed_effect_coefs,
+      value = TRUE, ignore.case = TRUE
     )
+    n_periods <- length(time_effect_names)
     repeated_time_effects <- rep(
       c(rep(0, n_periods - 1), 1), # assuming we want the last period
       length.out = n_rows * n_periods
@@ -275,50 +332,106 @@ get_confidence_set <- function(
     )
   }
 
-  # assemble the new data for prediction
+  # assemble the new data for prediction. Each block is labelled with the
+  # coefficient names its columns actually stand for, so the coefficients can
+  # be matched to the columns by name below.
   components <- list()
+  assembled_names <- character(0)
   if (include_center_effects) {
     components$center_effects <- repeated_center_effects_mat
+    assembled_names <- c(assembled_names, center_effect_names)
   }
   if (include_time_effects) {
     components$time_effects <- repeated_time_effects_mat
+    assembled_names <- c(assembled_names, time_effect_names)
   }
   components$new_grid <- new_grid
+  assembled_names <- c(assembled_names, colnames(new_grid))
   if (length(additional_covariates) > 0) {
+    # n_additional is length(additional_covariates), so the covariate names
+    # already line up with the columns one for one
     components$additional <- repeated_additional_mat
+    assembled_names <- c(assembled_names, additional_covariates)
   }
   if (length(center_characteristics) > 0) {
+    # this block is as wide as center_characteristics_optimization_values,
+    # which validate_inputs() requires to match center_characteristics in
+    # length and order
     components$center_cha <- repeated_center_cha_mat
+    assembled_names <- c(assembled_names, block_names(
+      center_characteristics, n_center_cha,
+      "unmatched center characteristic "
+    ))
   }
   new_data <- as.data.frame(do.call(cbind, components))
   new_data <- cbind(Intercept = 1, new_data)
-  colnames(new_data) <- names(fitted_model$coefficients)
+  # "(Intercept)" is the name glm() gives the intercept coefficient
+  colnames(new_data) <- c("(Intercept)", assembled_names)
+
+  # pair the coefficients with the columns they belong to BY NAME. The columns
+  # above are assembled in the order outcome_model_fitting() builds the model
+  # formula in, so a model fitted with its terms in some other order has its
+  # coefficients in that other order too, and pairing them by position would
+  # silently multiply every column by the wrong coefficient. Reordering the
+  # coefficients rather than the columns also keeps new_data lined up with the
+  # var-cov matrix the continuous branch builds from predictors_data.
+  # Backticks are stripped from both sides before matching, since an
+  # interaction term is named `a:b` in the model formula and glm keeps the
+  # backticks in the coefficient name, while a caller may pass it either way.
+  model_coefs <- coef(fitted_model)
+  coef_keys <- gsub("`", "", names(model_coefs))
+  column_keys <- gsub("`", "", colnames(new_data))
+  coef_positions <- match(column_keys, coef_keys)
+  # the match has to be one to one in both directions. A coefficient with no
+  # column would otherwise be dropped silently, and a duplicated name on
+  # either side would make the pairing ambiguous.
+  if (anyNA(coef_positions) ||
+    length(coef_keys) != length(column_keys) ||
+    anyDuplicated(coef_keys) > 0 || anyDuplicated(column_keys) > 0) {
+    describe <- function(x) {
+      if (length(x) > 0) paste(x, collapse = ", ") else "none"
+    }
+    stop(paste0(
+      "The coefficients of 'fitted_model' do not match the predictors the ",
+      "confidence set is computed over.\n",
+      "  ", length(model_coefs), " coefficient(s), ", ncol(new_data),
+      " predictor(s)\n",
+      "  coefficient(s) with no matching predictor: ",
+      describe(names(model_coefs)[!coef_keys %in% column_keys]), "\n",
+      "  predictor(s) with no matching coefficient: ",
+      describe(colnames(new_data)[!column_keys %in% coef_keys]), "\n",
+      "  predictor(s) named more than once: ",
+      describe(unique(column_keys[duplicated(column_keys)])), "\n",
+      "'fitted_model' must be fitted on exactly the intercept, the fixed ",
+      "center and time effects, the intervention components, the additional ",
+      "covariates and the center characteristics passed here. The order of ",
+      "its terms does not matter."
+    ))
+  }
+  model_coefs <- model_coefs[coef_positions]
 
   # get critical value based on the given alpha value
   critical_value <- qnorm(1 - confidence_set_alpha / 2)
 
   if (outcome_type == "binary") {
+    # vcov() is indexed by the same coefficient names, so reorder it the same
+    # way the coefficients were
+    model_vcov <- vcov(fitted_model)[
+      coef_positions, coef_positions,
+      drop = FALSE
+    ]
     new_data <- as.matrix(new_data)
-    pred_all <- expit(new_data %*% coef(fitted_model))
+    pred_all <- expit(new_data %*% model_coefs)
     se_pred_all <- sqrt(
-      diag((new_data) %*% vcov(fitted_model) %*% t(new_data))
+      diag((new_data) %*% model_vcov %*% t(new_data))
     ) * pred_all * (1 - pred_all)
 
     # lower and upper bounds of predictions
     lb_prob_all <- pred_all - critical_value * se_pred_all
     ub_prob_all <- pred_all + critical_value * se_pred_all
+    # the shared code below turns these bounds into the confidence set and
+    # its size, for both outcome types
     ci_prob_all <- cbind(lb_prob_all, ub_prob_all)
-    valid_rows <- complete.cases(ci_prob_all) # Identify rows without NA values
-    ci_prob_all_cleaned <- ci_prob_all[valid_rows, , drop = FALSE]
-
-    # calculate percentage of interventions
-    # that are included in the confidence set
-    set_size_intervals <- sum(apply(
-      ci_prob_all_cleaned,
-      1,
-      function(y) findInterval(x = outcome_goal, vec = y)
-    ) == 1)
-    confidence_set_size_percentage <- (set_size_intervals - 1) / (n_rows - 1)
   } else if (outcome_type == "continuous") {
     # link is either "logit" or "identity" in your usage
     # If link == "logit", use the logistic-like approach
@@ -548,9 +661,11 @@ get_confidence_set <- function(
       link = link
     )
 
-    # get predicted values
+    # get predicted values. vcov_matrix is not built from the fitted model's
+    # coefficients but from predictors_data, which is in the assembly order,
+    # so it is used as it comes and is not reordered with the coefficients.
     new_data <- as.matrix(new_data)
-    pred_all <- (new_data %*% as.matrix(coef(fitted_model)))
+    pred_all <- (new_data %*% as.matrix(model_coefs))
 
     # Calculate standard errors for all rows
     std_er_all <- suppressWarnings({
@@ -575,34 +690,53 @@ get_confidence_set <- function(
       # For "logit" (or other logistic-like) link, apply expit.
       ci_prob_all <- expit(cbind(lb_prob_all, ub_prob_all))
     }
-    valid_rows <- complete.cases(ci_prob_all) # Identify rows without NA values
-    ci_prob_all_cleaned <- ci_prob_all[valid_rows, , drop = FALSE]
-
-    # calculate percentage of interventions that are included
-    # in the confidence set
-    set_size_intervals <- sum(apply(
-      ci_prob_all_cleaned,
-      1,
-      function(y) findInterval(x = outcome_goal, vec = y)
-    ) == 1)
-    confidence_set_size_percentage <- (set_size_intervals - 1) / (n_rows - 1)
   }
 
-  # obtain the confidence set
-  cs_row_indices <- which((apply(
-    ci_prob_all_cleaned,
+  # rows whose interval could not be computed (an NA bound) cannot be tested
+  # against the outcome goal, so they are dropped. Rows are identified by their
+  # position in grid_x throughout, so keep the original row numbers rather than
+  # renumbering the kept rows: ci_prob_all keeps its full length and only the
+  # dropped rows are marked as not covering the goal.
+  valid_rows <- complete.cases(ci_prob_all) # Identify rows without NA values
+
+  # rows whose interval covers the outcome goal, i.e. lower <= goal <= upper.
+  # findInterval() returns 1 exactly for that case. Indices are grid_x row
+  # numbers, so row 1 is rec_int and rows 2+ are the grid interventions.
+  covers_goal <- logical(n_rows)
+  covers_goal[valid_rows] <- apply(
+    ci_prob_all[valid_rows, , drop = FALSE],
     1,
     function(y) findInterval(x = outcome_goal, vec = y)
-  ) == 1) == 1)
+  ) == 1
 
-  # if there is at most one row in the confidence set, it means the
-  # recommended intervention (the first row) is the only intervention in the
-  # confidence set (== 1), or not even the recommended intervention's
-  # confidence interval covers the outcome goal (== 0). In either case there
-  # is no confidence set to report.
-  if (length(cs_row_indices) <= 1) {
+  # the confidence interval at the recommended intervention, reported whether
+  # or not it covers the outcome goal, so callers do not have to look for
+  # rec_int inside the confidence set. NULL when it could not be computed.
+  rec_int_ci <- if (valid_rows[1]) {
+    c(
+      lower = round(ci_prob_all[1, 1], 3),
+      upper = round(ci_prob_all[1, 2], 3)
+    )
+  } else {
+    NULL
+  }
+
+  # the confidence set is the set of GRID interventions whose interval covers
+  # the outcome goal. Row 1 (rec_int) is excluded: it is reported through
+  # rec_int_ci, and it is not necessarily a grid intervention.
+  cs_row_indices <- which(covers_goal[-1]) + 1
+
+  # the size of the confidence set as a fraction of the grid. Both the
+  # numerator and the denominator count grid interventions only.
+  confidence_set_size_percentage <- length(cs_row_indices) / n_grid_rows
+
+  # no grid intervention's confidence interval covers the outcome goal, so
+  # there is no confidence set to report. rec_int_ci is still returned, since
+  # it does not depend on the confidence set being non-empty.
+  if (length(cs_row_indices) == 0) {
     return(list(
-      confidence_set_size_percentage = 0,
+      confidence_set_size_percentage = confidence_set_size_percentage,
+      rec_int_ci = rec_int_ci,
       cs = NULL
     ))
   }
@@ -638,9 +772,11 @@ get_confidence_set <- function(
     names(cs) <- c(original_cs_name, center_characteristics)
   }
 
+  # cs_row_indices are grid_x row numbers, and ci_prob_all is indexed by the
+  # same row numbers, so the bounds line up with the cs rows they belong to.
   cs_output_names <- names(cs)
-  ci_lower_bound <- round(ci_prob_all_cleaned[cs_row_indices, 1], 3)
-  ci_upper_bound <- round(ci_prob_all_cleaned[cs_row_indices, 2], 3)
+  ci_lower_bound <- round(ci_prob_all[cs_row_indices, 1], 3)
+  ci_upper_bound <- round(ci_prob_all[cs_row_indices, 2], 3)
 
   cs <- cbind(
     cs,
@@ -660,6 +796,7 @@ get_confidence_set <- function(
 
   return(list(
     confidence_set_size_percentage = confidence_set_size_percentage,
+    rec_int_ci = rec_int_ci,
     cs = cs
   ))
 }

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -748,14 +748,30 @@ get_confidence_set <- function(
     # by another column's variance and there would be nothing to show it.
     vcov_keys <- gsub("`", "", colnames(vcov_matrix))
     vcov_positions <- match(column_keys, vcov_keys)
-    if (anyNA(vcov_positions) || anyDuplicated(vcov_keys) > 0) {
+    # The pairing must be one to one in BOTH directions. Matching only the
+    # assembled columns would let an EXTRA column of predictors_data through:
+    # it widens the matrix built from them, the extra row and column are
+    # dropped by the subset below, and every remaining variance is silently
+    # taken from the wrong fit.
+    extra_vcov_keys <- setdiff(vcov_keys, column_keys)
+    if (anyNA(vcov_positions) || anyDuplicated(vcov_keys) > 0 ||
+      length(extra_vcov_keys) > 0) {
       stop(paste0(
         "The columns of 'predictors_data' do not match the predictors the ",
         "confidence set is computed over, so the variance-covariance matrix ",
         "built from them cannot be paired with them.\n",
         "  predictor(s) with no matching column of 'predictors_data': ",
         paste(
-          colnames(new_data)[is.na(vcov_positions)],
+          if (anyNA(vcov_positions)) {
+            colnames(new_data)[is.na(vcov_positions)]
+          } else {
+            "none"
+          },
+          collapse = ", "
+        ), "\n",
+        "  column(s) of 'predictors_data' matching no predictor: ",
+        paste(
+          if (length(extra_vcov_keys) > 0) extra_vcov_keys else "none",
           collapse = ", "
         ), "\n",
         "'predictors_data' must hold exactly the columns the model was ",

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -13,6 +13,11 @@
 #' The weights need to sum up to 1.
 #' @param include_time_effects A boolean. Specifies whether the fixed time
 #' effects should be included in the outcome model.
+#' @param time_effect_optimization_value The period the confidence set is
+#' computed at, as the value of the "period" column that identifies it. The
+#' recommended intervention and the estimated outcome reported alongside the
+#' confidence set are computed at this period, so the interval is computed at
+#' it too. Required when include_time_effects is TRUE.
 #' @param additional_covariates A character vector. The names of the columns in
 #' the dataset that represent additional covariates that need to be included
 #' in the outcome model. This includes interaction terms or any other additional
@@ -148,6 +153,7 @@ get_confidence_set <- function(
     include_center_effects = FALSE,
     center_weights_for_outcome_goal = 1,
     include_time_effects = FALSE,
+    time_effect_optimization_value = NULL,
     additional_covariates = NULL,
     intervention_components,
     include_interaction_terms = FALSE,
@@ -230,18 +236,23 @@ get_confidence_set <- function(
     new_grid <- grid_x
   }
 
-  # the coefficient names glm gave the fixed-effect dummy columns. Every name
-  # the assembly below can supply for itself is set aside first, so a covariate
-  # whose own name begins with "center" or "period" is not mistaken for a
-  # dummy. glm expands a factor into one dummy per non-reference level, in
-  # level order, which is also the order the dummy columns are built in below.
+  # the coefficient names glm gave each term of the fitted model, so every
+  # block below can be labelled with the coefficients it actually stands for.
+  # glm expands a factor term into one dummy coefficient per non-reference
+  # level and names the dummies after the levels, so a term's own name is in
+  # general not one of its coefficient names: a column 'arm' with levels
+  # post/pre is a coefficient named 'armpre'. NULL when the mapping cannot be
+  # established, in which case every term is taken to carry a coefficient of
+  # its own name, which is what the checks below then report as unmatched.
+  coef_mapping <- term_coef_names(fitted_model)
+  model_coef_names <- names(coef(fitted_model))
+  # every name the assembly below can supply for itself, set aside so the
+  # fallback in fixed_effect_coef_names() does not take a covariate whose own
+  # name begins with "center" or "period" for a fixed-effect dummy.
   named_predictors <- gsub("`", "", c(
     "(Intercept)", intervention_components, additional_covariates,
     center_characteristics
   ))
-  fixed_effect_coefs <- names(coef(fitted_model))[
-    !gsub("`", "", names(coef(fitted_model))) %in% named_predictors
-  ]
 
   # the names the assembled columns of one block carry. A block whose width and
   # number of coefficient names disagree cannot be matched at all, so it is
@@ -272,7 +283,9 @@ get_confidence_set <- function(
     # center_weights_for_outcome_goal is in center level order, so column i
     # above is the i-th non-reference center, which is the i-th center dummy.
     center_effect_names <- block_names(
-      grep("^center", fixed_effect_coefs, value = TRUE, ignore.case = TRUE),
+      fixed_effect_coef_names(
+        "center", coef_mapping, model_coef_names, named_predictors
+      ),
       n_centers,
       "unmatched center effect "
     )
@@ -281,15 +294,31 @@ get_confidence_set <- function(
   # add time effects (if specified) to the data that
   # will be used for predictions
   if (include_time_effects) {
-    # one column per time dummy, in period level order, so the last column is
-    # the last period, which is the one set to 1 below
-    time_effect_names <- grep(
-      "^period", fixed_effect_coefs,
-      value = TRUE, ignore.case = TRUE
+    # one column per time dummy, in period level order
+    time_effect_names <- fixed_effect_coef_names(
+      "period", coef_mapping, model_coef_names, named_predictors
     )
     n_periods <- length(time_effect_names)
+    if (n_periods == 0) {
+      stop(paste0(
+        "'include_time_effects' is TRUE but no fixed time effect coefficient ",
+        "could be identified in 'fitted_model'. The model must be fitted with ",
+        "a 'period' term, as outcome_model_fitting() builds it, so the ",
+        "confidence set can be computed at a single period."
+      ))
+    }
+    # the confidence set is computed at ONE period, the same one the
+    # recommended intervention and the reported estimated outcome are computed
+    # at, so the interval and the point estimate refer to the same quantity.
+    # It used to be hardcoded to the last period, so with any other requested
+    # period the reported interval was the interval of a different period than
+    # the reported point estimate, and could exclude it outright. The reference
+    # period has no dummy of its own and is all-zero columns.
+    indicators <- time_effect_indicator(
+      fitted_model, time_effect_names, time_effect_optimization_value
+    )
     repeated_time_effects <- rep(
-      c(rep(0, n_periods - 1), 1), # assuming we want the last period
+      indicators,
       length.out = n_rows * n_periods
     )
     repeated_time_effects_mat <- matrix(
@@ -303,7 +332,17 @@ get_confidence_set <- function(
   # add additional covariates (if specified) to the data that
   # will be used for predictions
   if (length(additional_covariates) > 0) {
-    n_additional <- length(additional_covariates)
+    # one column per coefficient a covariate expands into, not one column per
+    # covariate: a factor or character covariate is one coefficient per
+    # non-reference level, so it needs that many columns. Every column is 0,
+    # which is the value a numeric covariate has always been held at and, for
+    # a factor, is its reference level, so the same "held at 0" convention
+    # carries over one level down without any choice of level being made here.
+    additional_names <- unlist(
+      lapply(additional_covariates, predictor_coef_names, coef_mapping),
+      use.names = FALSE
+    )
+    n_additional <- length(additional_names)
     repeated_additional <- rep(
       0,
       length.out = n_rows * n_additional
@@ -348,18 +387,25 @@ get_confidence_set <- function(
   components$new_grid <- new_grid
   assembled_names <- c(assembled_names, colnames(new_grid))
   if (length(additional_covariates) > 0) {
-    # n_additional is length(additional_covariates), so the covariate names
-    # already line up with the columns one for one
+    # n_additional is length(additional_names), so the coefficient names the
+    # covariates expand into already line up with the columns one for one
     components$additional <- repeated_additional_mat
-    assembled_names <- c(assembled_names, additional_covariates)
+    assembled_names <- c(assembled_names, additional_names)
   }
   if (length(center_characteristics) > 0) {
     # this block is as wide as center_characteristics_optimization_values,
     # which validate_inputs() requires to match center_characteristics in
-    # length and order
+    # length and order, so one value per characteristic. A characteristic that
+    # is a factor with more than two levels expands to more coefficients than
+    # that, and which of its dummies the single value belongs to is not
+    # knowable, so the helper raises rather than guessing.
+    center_cha_names <- center_characteristic_coef_names(
+      center_characteristics, coef_mapping
+    )
     components$center_cha <- repeated_center_cha_mat
     assembled_names <- c(assembled_names, block_names(
-      center_characteristics, n_center_cha,
+      center_cha_names,
+      n_center_cha,
       "unmatched center characteristic "
     ))
   }
@@ -388,23 +434,45 @@ get_confidence_set <- function(
   if (anyNA(coef_positions) ||
     length(coef_keys) != length(column_keys) ||
     anyDuplicated(coef_keys) > 0 || anyDuplicated(column_keys) > 0) {
-    describe <- function(x) {
-      if (length(x) > 0) paste(x, collapse = ", ") else "none"
+    # only the causes that actually apply are listed, so the message always
+    # names what went wrong instead of reporting empty lists for the causes
+    # that did not. A duplicated name on either side is a cause of its own and
+    # is reported as such, since it can be the sole trigger.
+    reason <- function(label, x) {
+      if (length(x) > 0) {
+        paste0("  ", label, ": ", paste(x, collapse = ", "), "\n")
+      } else {
+        ""
+      }
     }
+    reasons <- paste0(
+      reason(
+        "coefficient(s) with no matching predictor",
+        names(model_coefs)[!coef_keys %in% column_keys]
+      ),
+      reason(
+        "predictor(s) with no matching coefficient",
+        colnames(new_data)[!column_keys %in% coef_keys]
+      ),
+      reason(
+        "coefficient(s) named more than once",
+        unique(coef_keys[duplicated(coef_keys)])
+      ),
+      reason(
+        "predictor(s) named more than once",
+        unique(column_keys[duplicated(column_keys)])
+      )
+    )
     stop(paste0(
       "The coefficients of 'fitted_model' do not match the predictors the ",
       "confidence set is computed over.\n",
       "  ", length(model_coefs), " coefficient(s), ", ncol(new_data),
       " predictor(s)\n",
-      "  coefficient(s) with no matching predictor: ",
-      describe(names(model_coefs)[!coef_keys %in% column_keys]), "\n",
-      "  predictor(s) with no matching coefficient: ",
-      describe(colnames(new_data)[!column_keys %in% coef_keys]), "\n",
-      "  predictor(s) named more than once: ",
-      describe(unique(column_keys[duplicated(column_keys)])), "\n",
+      reasons,
       "'fitted_model' must be fitted on exactly the intercept, the fixed ",
       "center and time effects, the intervention components, the additional ",
-      "covariates and the center characteristics passed here. The order of ",
+      "covariates and the center characteristics passed here. Its factor and ",
+      "character terms may expand to several coefficients each. The order of ",
       "its terms does not matter."
     ))
   }
@@ -453,14 +521,25 @@ get_confidence_set <- function(
         # For each column in predictors_data
         for (col in names(data)) {
           if (is.factor(data[[col]]) || is.character(data[[col]])) {
-            # Create dummies for categorical variables
-            # (using first level as reference)
-            levels <- unique(data[[col]])
+            # Create dummies for categorical variables, using the same
+            # reference level and the same dummy order glm() uses, so this
+            # matrix's columns pair with the model's coefficients. glm() drops
+            # the FIRST LEVEL, not the first value it happens to meet, and
+            # numbers the rest in level order, so unique() is wrong on both
+            # counts: it can pick a different reference level and order the
+            # dummies by first appearance. That made the variance estimate
+            # depend on the row order of the input data.
+            levels <- model_factor_levels(data[[col]])
             for (lev in levels[-1]) {
               dummy <- as.numeric(data[[col]] == lev)
               X <- cbind(X, dummy)
               colnames(X)[ncol(X)] <- paste0(col, lev)
             }
+          } else if (is.logical(data[[col]])) {
+            # glm() treats a logical column as a two-level factor whose only
+            # dummy is TRUE, and names the coefficient accordingly
+            X <- cbind(X, as.numeric(data[[col]]))
+            colnames(X)[ncol(X)] <- paste0(col, "TRUE")
           } else {
             # Numeric columns added as is
             X <- cbind(X, data[[col]])
@@ -661,9 +740,33 @@ get_confidence_set <- function(
       link = link
     )
 
-    # get predicted values. vcov_matrix is not built from the fitted model's
-    # coefficients but from predictors_data, which is in the assembly order,
-    # so it is used as it comes and is not reordered with the coefficients.
+    # vcov_matrix is not built from the fitted model but from predictors_data,
+    # so its rows and columns are in the column order of predictors_data, which
+    # a caller need not supply in the assembly order. Pair them with the
+    # assembled columns BY NAME, the same way the coefficients are, rather than
+    # trusting the two orders to agree: a mismatch would multiply every column
+    # by another column's variance and there would be nothing to show it.
+    vcov_keys <- gsub("`", "", colnames(vcov_matrix))
+    vcov_positions <- match(column_keys, vcov_keys)
+    if (anyNA(vcov_positions) || anyDuplicated(vcov_keys) > 0) {
+      stop(paste0(
+        "The columns of 'predictors_data' do not match the predictors the ",
+        "confidence set is computed over, so the variance-covariance matrix ",
+        "built from them cannot be paired with them.\n",
+        "  predictor(s) with no matching column of 'predictors_data': ",
+        paste(
+          colnames(new_data)[is.na(vcov_positions)],
+          collapse = ", "
+        ), "\n",
+        "'predictors_data' must hold exactly the columns the model was ",
+        "fitted on, i.e. 'center' and 'period' where the fixed effects are ",
+        "included, the intervention components, the additional covariates and ",
+        "the center characteristics. Their order does not matter."
+      ))
+    }
+    vcov_matrix <- vcov_matrix[vcov_positions, vcov_positions, drop = FALSE]
+
+    # get predicted values
     new_data <- as.matrix(new_data)
     pred_all <- (new_data %*% as.matrix(model_coefs))
 
@@ -690,6 +793,16 @@ get_confidence_set <- function(
       # For "logit" (or other logistic-like) link, apply expit.
       ci_prob_all <- expit(cbind(lb_prob_all, ub_prob_all))
     }
+  } else {
+    # ci_prob_all is assigned in the two branches above and read by the shared
+    # code below, so an unrecognised outcome type would reach that code with it
+    # undefined and fail on "object 'ci_prob_all' not found" instead of saying
+    # what is wrong. lago_optimization() validates outcome_type, so this is
+    # reachable only through a direct call.
+    stop(paste0(
+      "'outcome_type' must be either \"binary\" or \"continuous\", not \"",
+      outcome_type, "\"."
+    ))
   }
 
   # rows whose interval could not be computed (an NA bound) cannot be tested
@@ -767,8 +880,20 @@ get_confidence_set <- function(
   )
 
   if (length(center_characteristics) > 0) {
+    # one column per center characteristic, each holding that
+    # characteristic's own optimization value down every row: the confidence
+    # set is computed for a single center, so every row of it shares the same
+    # characteristic values. cbind()ing the value vector itself added ONE
+    # recycled column rather than one per characteristic, which errored on the
+    # name assignment below, or, when nrow(cs) was a multiple of the number of
+    # characteristics, silently produced a single column cycling through the
+    # values down the rows. validate_inputs() requires one value per
+    # characteristic, in the same order, so the two line up here.
     original_cs_name <- names(cs)
-    cs <- cbind(cs, center_characteristics_optimization_values)
+    cs <- cbind(cs, matrix(
+      rep(center_characteristics_optimization_values, each = nrow(cs)),
+      nrow = nrow(cs)
+    ))
     names(cs) <- c(original_cs_name, center_characteristics)
   }
 
@@ -798,5 +923,170 @@ get_confidence_set <- function(
     confidence_set_size_percentage = confidence_set_size_percentage,
     rec_int_ci = rec_int_ci,
     cs = cs
+  ))
+}
+
+# the coefficient names glm() gave each term of a fitted model, as a list whose
+# names are the term labels of the model formula and whose elements are the
+# coefficient names that term expands into. A term's own name is in general
+# NOT one of its coefficient names: glm expands a factor term into one dummy
+# per non-reference level and names each dummy after its level, so a column
+# 'arm' with levels post/pre becomes a coefficient named 'armpre'.
+# The mapping is read off the model matrix's "assign" attribute, which records
+# the term each of its columns came from and is what R itself pairs
+# coefficients with terms by. No name prefixes are compared, so a covariate
+# whose name is a prefix of another term's name, e.g. dose beside dose2, can
+# never be resolved to the other term's coefficients.
+# Returns NULL when the mapping cannot be rebuilt or does not account for
+# every coefficient, e.g. the data the model was fitted on is gone. A partial
+# mapping is discarded rather than used to label some blocks and not others.
+term_coef_names <- function(model) {
+  mapping <- tryCatch(
+    {
+      design <- model.matrix(model)
+      term_labels <- attr(terms(model), "term.labels")
+      assign_idx <- attr(design, "assign")
+      if (is.null(assign_idx) || length(term_labels) == 0) {
+        NULL
+      } else {
+        setNames(
+          lapply(
+            seq_along(term_labels),
+            function(i) colnames(design)[assign_idx == i]
+          ),
+          gsub("`", "", term_labels)
+        )
+      }
+    },
+    error = function(e) NULL
+  )
+  if (!is.null(mapping)) {
+    covered <- c("(Intercept)", unlist(mapping, use.names = FALSE))
+    if (!all(names(coef(model)) %in% covered)) {
+      mapping <- NULL
+    }
+  }
+  mapping
+}
+
+# the coefficient names one named predictor column stands for in the fitted
+# model. Looked up in the term-to-coefficient mapping, which is exact. A
+# predictor the mapping does not know, including the case of no mapping at
+# all, is taken to carry a single coefficient of its own name, so it is
+# reported as unmatched by the check in get_confidence_set() rather than
+# paired with a coefficient that merely looks like it.
+predictor_coef_names <- function(predictor, coef_mapping) {
+  matched <- coef_mapping[[gsub("`", "", predictor)]]
+  if (length(matched) == 0) predictor else matched
+}
+
+# the coefficient names of the fixed center or time effects, whose term is
+# "center" or "period": outcome_model_fitting() always puts them in the model
+# formula under those names, so the mapping names their dummies exactly.
+# The fallback for a model whose mapping could not be rebuilt is the prefix
+# search this used to do, restricted to the coefficients no other block can
+# claim so that a covariate named like center_size or period_flag is not
+# taken for a dummy.
+fixed_effect_coef_names <- function(term,
+                                    coef_mapping,
+                                    model_coef_names,
+                                    named_predictors) {
+  mapped <- coef_mapping[[term]]
+  if (length(mapped) > 0) {
+    return(mapped)
+  }
+  unclaimed <- model_coef_names[
+    !gsub("`", "", model_coef_names) %in% named_predictors
+  ]
+  grep(paste0("^", term), unclaimed, value = TRUE, ignore.case = TRUE)
+}
+
+# the coefficient name each center characteristic stands for, one per
+# characteristic and in the order they were given. A characteristic that is a
+# factor or character column with more than two levels expands to more than one
+# coefficient, and only one value per characteristic is supplied in
+# center_characteristics_optimization_values, so nothing says which of its
+# levels that value belongs to: say so rather than pick one, which would ignore
+# the value the caller supplied or hold the characteristic at a level it did not
+# ask for.
+center_characteristic_coef_names <- function(center_characteristics,
+                                            coef_mapping) {
+  resolved <- lapply(
+    center_characteristics, predictor_coef_names, coef_mapping
+  )
+  ambiguous <- center_characteristics[lengths(resolved) > 1]
+  if (length(ambiguous) > 0) {
+    stop(paste0(
+      "The center characteristic(s) ", paste(ambiguous, collapse = ", "),
+      " expand to more than one coefficient each in the outcome model, which ",
+      "means they are factor or character columns with more than two ",
+      "levels. Only one value per center characteristic is supplied, in ",
+      "'center_characteristics_optimization_values', so there is no way to ",
+      "say which of the levels the optimization should be computed at. ",
+      "Center characteristics with more than two levels are not supported: ",
+      "please recode them as numeric columns, or as one two-level column per ",
+      "level, and pass a value for each."
+    ))
+  }
+  unlist(resolved, use.names = FALSE)
+}
+
+# the levels of a column in the order glm() builds its dummies from, i.e. with
+# the reference level first. glm() uses the factor's levels, dropping any that
+# no row takes, and orders an unclassed character column's levels by sorting it,
+# which is what factor() does.
+model_factor_levels <- function(x) {
+  if (is.factor(x)) {
+    levels(droplevels(x))
+  } else {
+    levels(factor(x))
+  }
+}
+
+# a 0/1 indicator over the fixed time effect dummies of the model that selects
+# ONE period: 1 on the dummy of the requested period, 0 on the rest. The
+# reference period has no dummy of its own, so it is all zeros, which is a
+# legitimate answer rather than a failure to match.
+# The period the caller asked for is resolved against the period levels the
+# model was fitted on, which is the authoritative set, so it is never confused
+# with a coefficient that merely looks like it and a value that is not a period
+# at all raises rather than silently standing for the reference period.
+# The names are matched exactly, not by prefix: glm() names a period dummy with
+# the term name followed by the level, so the dummy of level "1" is exactly
+# "period1" and never "period10".
+time_effect_indicator <- function(model, time_effect_names, period_value) {
+  if (length(period_value) != 1 || is.na(period_value)) {
+    stop(paste0(
+      "'time_effect_optimization_value' must be a single non-missing value ",
+      "identifying the period to compute at when 'include_time_effects' is ",
+      "TRUE."
+    ))
+  }
+  period_levels <- model$xlevels[["period"]]
+  wanted <- as.character(period_value)
+  if (length(period_levels) > 0 && !wanted %in% period_levels) {
+    stop(paste0(
+      "'time_effect_optimization_value' (", wanted, ") is not one of the ",
+      "periods the outcome model was fitted on, which are ",
+      paste(period_levels, collapse = ", "),
+      ". It must be one of the values of the 'period' column."
+    ))
+  }
+  indicator <- rep(0, length(time_effect_names))
+  hits <- which(time_effect_names == paste0("period", wanted))
+  if (length(hits) == 1) {
+    indicator[hits] <- 1
+    return(indicator)
+  }
+  if (length(hits) == 0 && length(period_levels) > 0 &&
+    wanted == period_levels[1]) {
+    # the reference period, which glm() left out of the dummies on purpose
+    return(indicator)
+  }
+  stop(paste0(
+    "'time_effect_optimization_value' (", wanted, ") does not identify ",
+    "exactly one fixed time effect of the outcome model. Its time effect ",
+    "coefficient(s) are ", paste(time_effect_names, collapse = ", "),
+    ", plus the reference period, which has no coefficient of its own."
   ))
 }

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -524,14 +524,11 @@ lago_optimization <- function(
   )
 
   # The 95% confidence interval for the estimated outcome at the recommended
-  # intervention is row 1 of the raw confidence set (get_confidence_set()
-  # prepends rec_int as the first grid row). The object trims that row from $cs
-  # below, so capture the interval here before the trim.
-  est_outcome_ci <- if (include_confidence_set && !is.null(cs$cs)) {
-    c(
-      lower = cs$cs[1, ]$CI_lower_bound,
-      upper = cs$cs[1, ]$CI_upper_bound
-    )
+  # intervention. get_confidence_set() reports it as its own field, computed at
+  # the recommended intervention whether or not that interval covers the
+  # outcome goal, so it is available even when the confidence set is empty.
+  est_outcome_ci <- if (include_confidence_set) {
+    cs$rec_int_ci
   } else {
     NULL
   }
@@ -555,8 +552,9 @@ lago_optimization <- function(
         est_outcome_goal = est_outcome_goal,
         est_outcome_ci = est_outcome_ci,
         confidence_set_size_percentage = cs$confidence_set_size_percentage,
-        # cs$cs is NULL when no confidence set was found for the goal
-        cs = if (is.null(cs$cs)) NULL else cs$cs[-1, ],
+        # cs$cs already holds the grid interventions in the confidence set, and
+        # is NULL when no grid intervention qualifies for the goal
+        cs = cs$cs,
         # test_results is NULL unless a valid 'group' column was supplied
         test_results = test_results
       ),

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -432,6 +432,10 @@ lago_optimization <- function(
       step_size_results = step_size_results,
       include_center_effects = include_center_effects,
       include_time_effects = include_time_effects,
+      # the confidence set is computed at the same period the recommended
+      # intervention was, so the reported interval is the interval of the
+      # reported estimated outcome and not of some other period
+      time_effect_optimization_value = time_effect_optimization_value,
       intervention_components = intervention_components,
       additional_covariates = additional_covariates,
       center_characteristics = center_characteristics,

--- a/R/lago_presentation.R
+++ b/R/lago_presentation.R
@@ -179,13 +179,15 @@ lago_blocks <- function(x) {
 
   # --- outcome (estimated outcome, its 95% CI when available, and the outcome
   # goal when present). The CI is the interval for the estimated outcome at the
-  # recommended intervention (row 1 of the raw confidence set), carried on the
-  # object as est_outcome_ci.
+  # recommended intervention, which get_confidence_set() reports in its own
+  # rec_int_ci field, carried on the object as est_outcome_ci.
   outcome_rows <- paste0(
     "Estimated outcome: ", .lago_fmt_value(x$est_outcome_goal)
   )
   # Always show a CI line, with the old fallback wording when the interval is
-  # not available (no confidence set found, or the set was not requested).
+  # not available. The interval no longer depends on the confidence set being
+  # non-empty, so with the set requested it is missing only when the interval
+  # at the recommended intervention itself could not be computed.
   ci_line <- if (!is.null(x$est_outcome_ci)) {
     paste0(
       "95% CI for the estimated outcome: ",

--- a/R/lago_presentation.R
+++ b/R/lago_presentation.R
@@ -196,7 +196,10 @@ lago_blocks <- function(x) {
       .lago_fmt_value(x$est_outcome_ci[["upper"]])
     )
   } else if (!is.null(x$confidence_set_size_percentage)) {
-    "95% CI for the estimated outcome: not available (no confidence set found for the current goal)"
+    paste0(
+      "95% CI for the estimated outcome: not available (the interval at the ",
+      "recommended intervention could not be computed)"
+    )
   } else {
     "95% CI for the estimated outcome: not available (set include_confidence_set = TRUE)"
   }

--- a/R/rec_int_processor.R
+++ b/R/rec_int_processor.R
@@ -27,13 +27,39 @@ rec_int_processor <- function(
     outcome_name,
     icc = NULL,
     power_goal_cluster_id = NULL) {
+  # the coefficient names glm() gave each term of the model, so every
+  # coefficient below is picked out by the term it came from rather than by
+  # what its name happens to look like. A term's own name is in general NOT one
+  # of its coefficient names: glm() expands a factor or character term into one
+  # dummy per non-reference level and names each dummy after its level, so a
+  # column vol_hi with levels lo/hi is a coefficient named vol_hihi.
+  coef_mapping <- term_coef_names(model)
+  all_coefs <- coef(model)
+
   # get coefficients for the intervention components
   intervention_components_coeff <-
     model$coefficients[c("(Intercept)", intervention_components)]
 
-  # get coefficients for the center characteristics
+  # get coefficients for the center characteristics. Looked up through the term
+  # mapping: indexing model$coefficients by the raw column name yielded NA for
+  # a factor or character characteristic, since its coefficient is named after
+  # its level, and the NA then propagated through the estimated outcome and
+  # broke the optimization.
   if (!is.null(center_characteristics)) {
-    center_characteristics_coeff <- model$coefficients[center_characteristics]
+    center_characteristics_coeff <- all_coefs[
+      center_characteristic_coef_names(center_characteristics, coef_mapping)
+    ]
+    if (anyNA(center_characteristics_coeff)) {
+      stop(paste0(
+        "The center characteristic(s) ",
+        paste(
+          center_characteristics[is.na(center_characteristics_coeff)],
+          collapse = ", "
+        ),
+        " have no coefficient in the outcome model, so the recommended ",
+        "intervention cannot be computed at the values supplied for them."
+      ))
+    }
   }
 
   # set the values of center_cha_coeff_vec and
@@ -47,13 +73,24 @@ rec_int_processor <- function(
   }
 
   # get coefficients for facilities, which includes both the fixed
-  # center effects (if specified) and fixed time effects (if specified)
+  # center effects (if specified) and fixed time effects (if specified).
+  # The fixed center and time effect dummies are identified by the term they
+  # came from rather than by what their names happen to look like. A covariate
+  # whose own name starts with "center", e.g. center_size, came from its own
+  # term and so is never taken for a center dummy. Adding it to the
+  # center-level effects would shift every predicted outcome by its
+  # coefficient, and the first-element lookups downstream would then read a
+  # coefficient that is not a center effect at all.
+  # The fallback for a model whose term mapping could not be rebuilt, which
+  # outcome_model_fitting() does not produce, is the name search this used to
+  # do, anchored so that only a name beginning with the term is matched.
+  fixed_effect_coefs <- function(term) {
+    fixed_effect_coef_names(term, coef_mapping, names(all_coefs), character(0))
+  }
+
   if (include_center_effects) {
-    all_coefs <- coef(model)
     intercept_only <- all_coefs["(Intercept)"]
-    fixed_center_coefs <- all_coefs[
-      grep("center", names(all_coefs), ignore.case = TRUE)
-    ]
+    fixed_center_coefs <- all_coefs[fixed_effect_coefs("center")]
     # add intercept to each center coefficient to get "true" effects
     true_center_effects <- fixed_center_coefs + intercept_only
     all_center_lvl_effects <- c(intercept_only, true_center_effects)
@@ -61,16 +98,28 @@ rec_int_processor <- function(
     all_center_lvl_effects <- 0
   }
 
-  # add fixed time effect (if specified)
+  # add the fixed time effect of the requested period (if specified). The
+  # period is resolved against the period levels the model was fitted on and
+  # its dummy is matched by exact name, so a value that is not a period raises
+  # instead of contributing nothing. Matching by pattern let the requested
+  # period miss every dummy and silently return a zero-length coefficient,
+  # which collapsed all_center_lvl_effects to length zero and made the
+  # estimated outcome 0. The reference period contributes 0, since glm() leaves
+  # it out of the dummies and it is already carried by the intercept.
   if (include_time_effects) {
+    period_coefs <- fixed_effect_coefs("period")
+    if (length(period_coefs) == 0) {
+      stop(paste0(
+        "'include_time_effects' is TRUE but no fixed time effect coefficient ",
+        "could be identified in the outcome model. It must be fitted with a ",
+        "'period' term, as outcome_model_fitting() builds it."
+      ))
+    }
+    period_indicators <- time_effect_indicator(
+      model, period_coefs, time_effect_optimization_value
+    )
     all_center_lvl_effects <- all_center_lvl_effects +
-      all_coefs[
-        grep(
-          paste0("period", time_effect_optimization_value, "$"),
-          names(all_coefs),
-          ignore.case = TRUE
-        )
-      ]
+      sum(period_indicators * all_coefs[period_coefs])
   }
 
   # calculate default step size

--- a/man/get_confidence_set.Rd
+++ b/man/get_confidence_set.Rd
@@ -104,8 +104,18 @@ from the optimization step.}
 }
 \value{
 List(
-  confidence_set_size_percentage = <number>,
-  cs = <data.frame of interventions in the confidence set>
+  confidence_set_size_percentage = <number, the size of the confidence set
+    as a fraction of the grid. Both the count of qualifying interventions
+    and the size of the grid count grid interventions only, so rec_int is
+    excluded from each>,
+  rec_int_ci = <named numeric c(lower, upper) rounded to 3 decimal places,
+    the confidence interval at rec_int. Computed whether or not it covers
+    the outcome goal, so callers never have to look for rec_int inside cs.
+    NULL when that interval is not computable>,
+  cs = <data.frame of the grid interventions whose confidence interval
+    covers the outcome goal, with their interval bounds and cost. rec_int is
+    never one of its rows, and need not be a grid intervention at all.
+    NULL when no grid intervention qualifies>
 )
 }
 \description{
@@ -116,14 +126,13 @@ for the recommended interventions
 # Normally reached through lago_optimization(include_confidence_set = TRUE).
 # Called directly it needs the fitted outcome model and the recommended
 # intervention from the optimization step, so both are taken from a run of
-# the optimizer rather than refitting the model by hand: get_confidence_set()
-# binds its prediction matrix to the coefficient vector by position, so
-# passing opt$model is the reliable way to get that order right. A
-# hand-fitted model works only if its coefficients are in the order the
-# prediction matrix is assembled in: intercept, fixed center effects, fixed
-# time effects, intervention components, additional covariates, then center
-# characteristics. A wrong number of coefficients errors; a wrong order is
-# silent and returns a different confidence set.
+# the optimizer rather than refitting the model by hand. get_confidence_set()
+# binds its prediction matrix to the coefficient vector by name, so a
+# hand-fitted model may list its terms in any order. It must be fitted on
+# exactly the predictors passed here, though: the intercept, the fixed
+# center effects, the fixed time effects, the intervention components, the
+# additional covariates and the center characteristics. Any other set of
+# coefficients is an error naming what did not match.
 # The lower bounds start at 1 while the data also contains 0s, so the
 # optimizer warns about that; the warning is expected here.
 opt <- lago_optimization(
@@ -163,17 +172,23 @@ cs <- get_confidence_set(
   rec_int = opt$rec_int
 )
 
-# Fraction of the grid inside the 95\% confidence set. print() shows the
-# same number as a percentage.
+# Fraction of the grid inside the 95\% confidence set: 18 of the 200 grid
+# interventions qualify here (40 coaching values by 5 launch durations), so
+# 0.09. print() shows the same number as a percentage.
 cs$confidence_set_size_percentage
 
-# rec_int is prepended to the grid so its confidence interval is computed
-# too, and row 1 is that prepended row whenever rec_int's own interval
-# covers the outcome goal, as it does here. It need not be a grid point,
-# and lago_optimization() strips row 1 from the confidence set it returns.
-# Rows 2 and on are the grid points inside the confidence set.
-cs$cs[1, ]
-head(cs$cs[-1, ])
+# The confidence interval at the recommended intervention, reported in its
+# own field as c(lower, upper). It is computed whether or not it covers the
+# outcome goal, so it is available even when no grid intervention qualifies.
+# lago_optimization() reports this interval as $est_outcome_ci.
+cs$rec_int_ci
+
+# rec_int need not be one of the grid interventions, and here it is not:
+# its launch_duration is about 2.78 while the grid steps through whole
+# days. It is never a row of cs either, which holds the 18 qualifying grid
+# interventions and nothing else.
+opt$rec_int
+head(cs$cs)
 
 }
 \keyword{internal}

--- a/man/get_confidence_set.Rd
+++ b/man/get_confidence_set.Rd
@@ -9,6 +9,7 @@ get_confidence_set(
   include_center_effects = FALSE,
   center_weights_for_outcome_goal = 1,
   include_time_effects = FALSE,
+  time_effect_optimization_value = NULL,
   additional_covariates = NULL,
   intervention_components,
   include_interaction_terms = FALSE,
@@ -43,6 +44,12 @@ The weights need to sum up to 1.}
 
 \item{include_time_effects}{A boolean. Specifies whether the fixed time
 effects should be included in the outcome model.}
+
+\item{time_effect_optimization_value}{The period the confidence set is
+computed at, as the value of the "period" column that identifies it. The
+recommended intervention and the estimated outcome reported alongside the
+confidence set are computed at this period, so the interval is computed at
+it too. Required when include_time_effects is TRUE.}
 
 \item{additional_covariates}{A character vector. The names of the columns in
 the dataset that represent additional covariates that need to be included


### PR DESCRIPTION
## Fix the confidence set identifying things by position instead of by name

  Two root causes, both silent. Reported as four defects; fixing them surfaced
  seven more in the same path.

  **1. The recommended intervention was identified by grid position.**
  `get_confidence_set()` prepends it as row 1, and consumers picked it out as
  row 1. That only holds when its own interval covers the outcome goal. When it
  does not, the first qualifying row is an ordinary grid point that every
  consumer then treated as the recommendation. On the bundled data with
  `outcome_goal_intention = "minimize"` at `outcome_goal = 0.55`:

  | Reported | Was | Correct |
  |---|---|---|
  | `est_outcome_ci` | `0.516 0.553` (interval at grid point `c(10, 1)`) | `0.444 0.512` |
  | `nrow($cs)` | 6, having deleted `c(10, 1)` | 7 |
  | size | `0.03` | `0.035` (7 of 200) |
  | a one-point set | discarded as empty, size 0 | returned |

  Now: the recommendation's interval is its own field, `rec_int_ci`, always
  computed; `$cs` holds qualifying grid points only; the size counts grid points
  in both numerator and denominator.

  **2. The prediction matrix was paired with coefficients by position.**
  `colnames(new_data) <- names(coef(model))` renames columns but cannot reorder
  them, so a model fitted with terms in another order multiplied every column by
  the wrong coefficient. Six permutations of one model gave six answers, 1% to
  13%. Terms now resolve through `attr(model.matrix(model), "assign")`; a model
  that genuinely does not correspond raises an error naming both sides.

  ### Also fixed

  - `est_outcome_goal` reported as **`0`** with fixed time effects on the
    reference period
  - the interval computed at the last time period while the estimate used the
    requested one
  - a covariate named like `center_size` counted as a fixed center effect: one
    case recommended an intervention whose true outcome was 0.428 while
    reporting 0.6
  - coordinates and intervals mispaired once `complete.cases` dropped a row
  - the confidence set changing under a pure **row permutation** of the same data
  - factor covariates and center characteristics erroring or mispaired
  - multiple center characteristics crashing or silently recycling one column

  ### Verification

  `R CMD check --as-cran` findings identical to `main`. 205 tests pass with
  `NOT_CRAN=true` and **0 skips** (the default run skips 5 snapshots and both
  report tests, which is how several of these hid). **No test or snapshot
  edited.** README and vignette output unchanged. Every changed number verified
  by computing it from the fitted model, not by re-running the package.

  Reviewed adversarially over three rounds by three reviewers on separate lenses.
  Round 1 found two blockers, one a regression the first commit introduced.

  ### Note

  `get_confidence_set()` is exported, so `rec_int_ci` plus `$cs` no longer
  carrying the prepended row is a contract change. NEWS records it and says where
  numbers move: most runs with fixed time effects for the interval, and
  configurations where a covariate name was read as a fixed effect for the
  recommendation itself.

  Two pre-existing defects left out, in files this branch does not touch and
  equally wrong on `main`: `get_outcome.R` needs `sum()` where it uses an
  elementwise product, and `est_outcome_goal` is returned **negated** under
  `minimize`. One follow-up ticket.