### PR TITLE
Fix/minimize scale and center cha sum

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,17 +14,19 @@
   or below. An unachievable goal was also never detected, so the warning about
   shrinking towards the previous stage's intervention could not appear.
   Recommendations, costs and confidence sets change for minimize runs with a
-  logit link. Nothing changes for `maximize`, or for minimize with an identity
-  link, where negation was already the correct inverse.
+  logit link. Minimize with an identity link is unaffected, since negation was
+  already the correct inverse there. This particular fix changes nothing for
+  `maximize`, though the two fixes below do.
 * Fixed the recommended intervention being allowed outside
-  `intervention_lower_bounds` and `intervention_upper_bounds` when the
-  shrinking method was used. The interpolation the shrinking method performs
-  was not confined to the bounds, so it could return a value below the lower
-  bound, a value above the upper bound, or a value that was not finite. The
-  bundled data returned a `launch_duration` of 0.81 against a lower bound of 1.
-  A recommendation is now always within the bounds supplied. This affected both
-  goal directions: with a power goal and an unachievable outcome goal, the
-  maximize direction could return `Inf` as a recommended intervention.
+  `intervention_lower_bounds` and `intervention_upper_bounds`. The
+  interpolation the shrinking method performs was not confined to the bounds,
+  so for an outcome goal it could not reach it returned a value above the upper
+  bound or one that was not finite: asking for an outcome of 1 returned `Inf`,
+  and with lower bounds of 10 it returned a negative intervention of -23.3.
+  Both are reachable in the maximize direction with no power goal. A
+  recommendation is now brought onto the bounds supplied. The numerical
+  optimizer can still stop a solver tolerance outside them, on the order of
+  1e-4, and that residue is projected back rather than reported.
 * Fixed the numerical optimization returning the most expensive of its
   candidate solutions rather than the cheapest. The optimizer runs from several
   starting points and all of them satisfy the outcome goal, so the intended

--- a/NEWS.md
+++ b/NEWS.md
@@ -199,3 +199,16 @@
 * `lago_optimization()` now accepts a standalone power goal, an outcome goal, or
   both together, taking the higher of the outcome goal and the power-implied
   outcome. (#40)
+
+## Known limitations
+
+* The confidence set is the set of interventions whose confidence interval
+  covers the outcome goal, which is a two sided test and does not depend on
+  `outcome_goal_intention`. Under `outcome_goal_intention = "minimize"` it can
+  therefore contain interventions whose estimated outcome is above the goal, and
+  which cost more than the recommendation, because their interval still reaches
+  the goal from above. Read the confidence set as the interventions the data
+  cannot distinguish from the goal, not as the interventions that meet it. The
+  estimated outcome and its interval, reported as `est_outcome_goal` and
+  `est_outcome_ci`, are computed at the recommended intervention and are
+  direction independent, so they are unaffected.

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,10 +20,12 @@
 * Fixed the recommended intervention being allowed outside
   `intervention_lower_bounds` and `intervention_upper_bounds`. The
   interpolation the shrinking method performs was not confined to the bounds,
-  so for an outcome goal it could not reach it returned a value above the upper
-  bound or one that was not finite: asking for an outcome of 1 returned `Inf`,
-  and with lower bounds of 10 it returned a negative intervention of -23.3.
-  Both are reachable in the maximize direction with no power goal. A
+  so for an outcome goal it could not reach it returned a value below the lower
+  bound, a value above the upper bound, or a value that was not finite: asking
+  for an outcome of 1 returned `Inf`, and with lower bounds of 10 it returned a
+  negative intervention of -23.3. Both are reachable in the maximize direction
+  with no power goal, and a value below the lower bound is reachable on its own
+  at ordinary goals such as 0.995. A
   recommendation is now brought onto the bounds supplied. The numerical
   optimizer can still stop a solver tolerance outside them, on the order of
   1e-4, and that residue is projected back rather than reported.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,48 @@
 # LAGO 1.0.12
 
+* Fixed `outcome_goal_intention = "minimize"` ignoring the outcome goal. The
+  minimize direction is implemented by negating the fitted coefficients and
+  maximizing instead, and the result was converted back by negating it. For a
+  logit link that is not the inverse of the transform: negating the
+  coefficients maps a probability to one minus itself, not to minus itself. The
+  estimated outcome was therefore reported as a negative probability, and, more
+  seriously, the goal handed to the optimization was negated while the quantity
+  it constrains stays between 0 and 1, so the constraint held for every
+  candidate and the recommendation was driven by cost alone. On a constructed
+  example the optimizer returned the do-nothing intervention at zero cost, with
+  a true outcome probability of 0.94, and reported it as meeting a goal of 0.5
+  or below. An unachievable goal was also never detected, so the warning about
+  shrinking towards the previous stage's intervention could not appear.
+  Recommendations, costs and confidence sets change for minimize runs with a
+  logit link. Nothing changes for `maximize`, or for minimize with an identity
+  link, where negation was already the correct inverse.
+* Fixed the recommended intervention being allowed outside
+  `intervention_lower_bounds` and `intervention_upper_bounds` when the
+  shrinking method was used. The interpolation the shrinking method performs
+  was not confined to the bounds, so it could return a value below the lower
+  bound, a value above the upper bound, or a value that was not finite. The
+  bundled data returned a `launch_duration` of 0.81 against a lower bound of 1.
+  A recommendation is now always within the bounds supplied. This affected both
+  goal directions: with a power goal and an unachievable outcome goal, the
+  maximize direction could return `Inf` as a recommended intervention.
+* Fixed the numerical optimization returning the most expensive of its
+  candidate solutions rather than the cheapest. The optimizer runs from several
+  starting points and all of them satisfy the outcome goal, so the intended
+  choice is the lowest-cost one. The recommendation and its cost change where
+  the starting points converged to different local optima.
+* Fixed the estimated outcome being wrong when more than one center
+  characteristic was supplied. One term of the linear predictor was not summed,
+  so it stayed a vector and the surrounding arithmetic recycled it. With a
+  single center characteristic the term is a scalar and results are unchanged.
+* `link = "probit"` and `link = "log"` are no longer accepted. They passed
+  validation and were documented as supported, but the outcome calculation only
+  ever implemented `logit` and `identity` and returned the linear predictor
+  unchanged for the other two, reporting it as a probability or a mean. Asking
+  for an outcome of 0.20 or below under `probit` returned an intervention
+  reported as achieving exactly 0.200000, where the probability it corresponds
+  to is 0.579. Supporting either link needs inverse-link and variance paths the
+  confidence set does not have, so they are rejected rather than silently
+  wrong.
 * Fixed the 95% confidence interval reported for the estimated outcome.
   `get_confidence_set()` prepends the recommended intervention to the
   confidence-set grid so that its interval is computed alongside the grid

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -31,7 +31,9 @@
 #' @param outcome_data A vector. The input data containing the outcome
 #' of interest.
 #' @param fitted_model A glm(). The fitted glm() outcome model.
-#' @param link A character string. The link function (e.g. "logit", "identity").
+#' @param link A character string. The link function the interval is computed
+#' on, either "logit" or "identity". These are the only links the outcome
+#' machinery implements, see supported_outcome_links().
 #' @param outcome_goal A numeric value. Specifies the outcome goal, a desired
 #' probability or mean value.
 #' @param outcome_type A character string. Specifies the type of the outcome.
@@ -172,6 +174,17 @@ get_confidence_set <- function(
     cluster_id = NULL,
     cost_list_of_vectors,
     rec_int) {
+  # the interval is built on the outcome scale of ONE of the links the package
+  # implements, and both branches below assume it is one of those two: the
+  # continuous branch applies expit() to anything that is not "identity", and
+  # the binary branch applies it unconditionally. So any other link silently
+  # produced a logit-scale interval regardless of what was asked for. This
+  # function is exported and so reachable with any link at all, not only
+  # through lago_optimization(), which is why the link is checked here as well
+  # as in validate_inputs().
+  if (!link %in% supported_outcome_links()) {
+    stop(unsupported_link_message(link))
+  }
   # Create a list to store sequences for each component
   sequences <- list()
   # Generate sequences for each intervention component
@@ -501,7 +514,8 @@ get_confidence_set <- function(
     # its size, for both outcome types
     ci_prob_all <- cbind(lb_prob_all, ub_prob_all)
   } else if (outcome_type == "continuous") {
-    # link is either "logit" or "identity" in your usage
+    # link is either "logit" or "identity", the only links the outcome
+    # machinery implements, see supported_outcome_links().
     # If link == "logit", use the logistic-like approach
     # If link == "identity", use linear approach.
 

--- a/R/get_outcome.R
+++ b/R/get_outcome.R
@@ -1,3 +1,38 @@
+# The link functions the outcome machinery actually implements.
+#
+# A link belongs here only when EVERY step that consumes one handles it:
+# get_outcome() below has to apply its inverse, flip_outcome_scale() below has
+# to invert the "minimize" coefficient negation on its outcome scale, and
+# get_confidence_set() has to build an interval on that same scale. Only
+# "logit" and "identity" are handled throughout, so only those two are
+# supported, and this one vector is what validate_inputs() accepts and what
+# both functions below branch on. Keeping the set in a single place is what
+# stops the three from drifting apart again.
+#
+# "probit" and "log" used to be accepted by validate_inputs() and are not here.
+# Nothing implemented their inverse links, so they fell through to the identity
+# branch of get_outcome() and the linear predictor was reported as though it
+# were the probability or the mean. For "log" the gap is not merely unwritten
+# code: with two or more center-level effects the "minimize" flip below cannot
+# be written at all (see the note on flip_outcome_scale()).
+supported_outcome_links <- function() {
+  c("logit", "identity")
+}
+
+
+# The message for a link none of the outcome machinery implements. Shared by
+# validate_inputs() and by the two functions below so the supported set is
+# written down once and every refusal names the same set.
+unsupported_link_message <- function(link) {
+  paste0(
+    "link=", link, ". The link option has to be one of the following: ",
+    paste(supported_outcome_links(), collapse = ", "), ". Only these links ",
+    "are implemented by the outcome and confidence set calculations, so any ",
+    "other link would be reported on the wrong scale rather than computed."
+  )
+}
+
+
 get_outcome <- function(
     center_weights_for_outcome_goal,
     all_center_lvl_effects,
@@ -17,26 +52,30 @@ get_outcome <- function(
   # a no-op there and that common case is unchanged.
   center_cha_effect <- sum(center_cha_coeff_vec * center_cha)
 
+  # the linear predictor, one value per center-level effect. Computed once and
+  # then mapped onto the outcome scale by the inverse link below, so the two
+  # link branches can differ ONLY in that inverse and cannot come to disagree
+  # about the predictor itself.
+  linear_predictor <- all_center_lvl_effects +
+    sum(beta * int_vector) +
+    center_cha_effect +
+    ifelse(length(all_center_lvl_effects) > 1, -beta[1], 0)
+
+  # the reported outcome is a weighted mean of the inverse link of the linear
+  # predictor, with weights summing to 1. An unhandled link has no inverse to
+  # apply here, so it is refused rather than passed through: returning the
+  # linear predictor would report it as if it were the probability or the mean
+  # the caller asked for, which is a wrong number and not an error.
   if (link == "logit") {
     outcome <- sum(
-      center_weights_for_outcome_goal *
-        rje::expit(
-          all_center_lvl_effects +
-            sum(beta * int_vector) +
-            center_cha_effect +
-            ifelse(length(all_center_lvl_effects) > 1, -beta[1], 0)
-        )
+      center_weights_for_outcome_goal * rje::expit(linear_predictor)
+    )
+  } else if (link == "identity") {
+    outcome <- sum(
+      center_weights_for_outcome_goal * linear_predictor
     )
   } else {
-    outcome <- sum(
-      center_weights_for_outcome_goal *
-        (
-          all_center_lvl_effects +
-            sum(beta * int_vector) +
-            center_cha_effect +
-            ifelse(length(all_center_lvl_effects) > 1, -beta[1], 0)
-        )
-    )
+    stop(unsupported_link_message(link))
   }
 
   return(outcome)
@@ -50,23 +89,33 @@ get_outcome <- function(
 # one place that map is written down.
 #
 # It is NOT always a negation, because get_outcome() applies the inverse link:
-#   - identity (and any non-logit link, which get_outcome treats linearly):
-#     the outcome is the linear predictor, so negating the coefficients
-#     negates the outcome.        flip(y) = -y
+#   - identity: the outcome is the linear predictor, so negating the
+#     coefficients negates the outcome.        flip(y) = -y
 #   - logit: the outcome is a weighted mean of expit(eta) with weights summing
 #     to 1, and expit(-eta) = 1 - expit(eta), so negating the coefficients
 #     REFLECTS the probability about 1/2, it does not negate it.
-#                                 flip(p) = 1 - p
+#                                             flip(p) = 1 - p
 #
 # Either way flip() is an order-reversing involution on the outcome scale, so
 # maximizing the flipped outcome is exactly minimizing the original one, and
 # "flipped outcome >= flip(goal)" is exactly "original outcome <= goal".
 # Applying it to the goal on the way in and to the estimated outcome on the
 # way out is what keeps the two comparable.
+#
+# Every link needs its own entry here, and it is not a formality: for a "log"
+# link the map cannot be written down at all once there is more than one
+# center-level effect. The outcome is sum(w_i * exp(eta_i)) and the flipped
+# outcome is sum(w_i * exp(-eta_i)), and two different eta vectors with the
+# same outcome can have different flipped outcomes, so there is no function of
+# the outcome alone to write. That is why the supported set above is a property
+# of this function as much as of get_outcome(), and why an unhandled link is
+# refused in both rather than defaulted to the linear case.
 flip_outcome_scale <- function(value, link) {
   if (link == "logit") {
     1 - value
-  } else {
+  } else if (link == "identity") {
     -1 * value
+  } else {
+    stop(unsupported_link_message(link))
   }
 }

--- a/R/get_outcome.R
+++ b/R/get_outcome.R
@@ -6,13 +6,24 @@ get_outcome <- function(
     center_cha_coeff_vec,
     center_cha,
     link) {
+  # The center-characteristic contribution is a single number: the inner
+  # product of the characteristics' coefficients with the values the
+  # recommendation is computed at. It is summed for the same reason
+  # sum(beta * int_vector) is. Left as the elementwise product it stayed a
+  # VECTOR as soon as there were two or more center characteristics, and it
+  # then recycled against all_center_lvl_effects (which is per center-level
+  # effect, not per characteristic), silently producing a wrong outcome. With
+  # exactly one characteristic the product is already length one, so sum() is
+  # a no-op there and that common case is unchanged.
+  center_cha_effect <- sum(center_cha_coeff_vec * center_cha)
+
   if (link == "logit") {
     outcome <- sum(
       center_weights_for_outcome_goal *
         rje::expit(
           all_center_lvl_effects +
             sum(beta * int_vector) +
-            center_cha_coeff_vec * center_cha +
+            center_cha_effect +
             ifelse(length(all_center_lvl_effects) > 1, -beta[1], 0)
         )
     )
@@ -22,11 +33,40 @@ get_outcome <- function(
         (
           all_center_lvl_effects +
             sum(beta * int_vector) +
-            center_cha_coeff_vec * center_cha +
+            center_cha_effect +
             ifelse(length(all_center_lvl_effects) > 1, -beta[1], 0)
         )
     )
   }
 
   return(outcome)
+}
+
+
+# The "minimize" direction is implemented by negating the fitted coefficients
+# (see lago_optimization()), which turns "reach an outcome at most as large as
+# the goal" into the maximization problem every optimizer here already solves.
+# This is the map that negation induces on the OUTCOME scale, and it is the
+# one place that map is written down.
+#
+# It is NOT always a negation, because get_outcome() applies the inverse link:
+#   - identity (and any non-logit link, which get_outcome treats linearly):
+#     the outcome is the linear predictor, so negating the coefficients
+#     negates the outcome.        flip(y) = -y
+#   - logit: the outcome is a weighted mean of expit(eta) with weights summing
+#     to 1, and expit(-eta) = 1 - expit(eta), so negating the coefficients
+#     REFLECTS the probability about 1/2, it does not negate it.
+#                                 flip(p) = 1 - p
+#
+# Either way flip() is an order-reversing involution on the outcome scale, so
+# maximizing the flipped outcome is exactly minimizing the original one, and
+# "flipped outcome >= flip(goal)" is exactly "original outcome <= goal".
+# Applying it to the goal on the way in and to the estimated outcome on the
+# way out is what keeps the two comparable.
+flip_outcome_scale <- function(value, link) {
+  if (link == "logit") {
+    1 - value
+  } else {
+    -1 * value
+  }
 }

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -1,3 +1,35 @@
+# The warning for an outcome goal that no intervention inside the bounds is
+# estimated to reach, so that the recommendation falls back to shrinking
+# towards the previous stage's intervention.
+#
+# Which extreme is out of reach, and in which direction, depends on the
+# optimization direction: under "maximize" the goal is above everything
+# reachable, and under "minimize" it is below everything reachable. Only the
+# "maximize" sentence was ever written, and under "minimize" it named the wrong
+# extreme and the wrong inequality, i.e. it described a comparison that had not
+# happened. This was unreachable until the "minimize" goal constraint started
+# binding, since a vacuous constraint is never unachievable.
+unachievable_goal_message <- function(lower_outcome_goal) {
+  reason <- if (lower_outcome_goal) {
+    paste(
+      "Since the minimum estimated achievable outcome\n",
+      "is greater than the outcome goal,"
+    )
+  } else {
+    paste(
+      "Since the maximum estimated achievable outcome\n",
+      "is less than the outcome goal,"
+    )
+  }
+  paste(
+    "The outcome goal is not estimated to be achievable.",
+    reason,
+    "we will shrink the recommended intervention towards the\n",
+    "recommended intervention from the previous stage."
+  )
+}
+
+
 #' get_recommended_interventions
 #'
 #' @description Internal function that calculates the LAGO recommended
@@ -147,9 +179,28 @@ get_recommended_interventions <- function(
       power_goal_cluster_id = power_goal_cluster_id
     )
 
-    new_outcome_goal <- max(power_desired_outcome, outcome_goal)
+    effective_outcome_goal <- max(power_desired_outcome, outcome_goal)
   } else {
-    new_outcome_goal <- outcome_goal
+    effective_outcome_goal <- outcome_goal
+  }
+
+  # THE scale boundary on the way IN. outcome_goal arrives on the outcome scale
+  # the caller stated it on, and everything below optimizes on the flipped
+  # scale when lower_outcome_goal is TRUE (the "minimize" direction is
+  # implemented by negating the fitted coefficients, see lago_optimization()).
+  # So the flip is applied here, once, to the one goal the optimizers compare
+  # against, using the same flip_outcome_scale() that the un-flip below
+  # inverts. Doing it here rather than in the caller is what lets the original
+  # goal be REPORTED as the caller supplied it: it is carried through
+  # untouched in effective_outcome_goal instead of being recovered by flipping
+  # a flipped copy. The two flips would not compose to the identity in floating
+  # point on a logit link -- 1 - (1 - g) is off by up to an ulp of g -- so
+  # round-tripping would hand the confidence set a goal that differs from the
+  # user's in its last bits.
+  new_outcome_goal <- if (lower_outcome_goal) {
+    flip_outcome_scale(effective_outcome_goal, link)
+  } else {
+    effective_outcome_goal
   }
 
   # Function to create a cost function based on coefficients
@@ -170,9 +221,25 @@ get_recommended_interventions <- function(
     }
     # drop = FALSE keeps a one-column selection as a data.frame; without it,
     # data[, single_col] collapses to a vector and colMeans() errors.
-    shrink_to_int_values <- colMeans(
+    observed_mean_int_values <- colMeans(
       data[, all_components, drop = FALSE],
       na.rm = TRUE
+    )
+    # the shrinking method shrinks TOWARDS this vector and can return it
+    # unchanged, so it is a candidate recommendation and has to be one the user
+    # could actually implement, i.e. inside the bounds they gave. The observed
+    # column means are a property of the DATA and need not be: the bounds
+    # describe what the next stage may do, and validate_inputs() only warns
+    # when they exclude values the data contains. Left unprojected, an
+    # intervention the user's own bounds forbid was returned as the
+    # recommendation. Projecting onto the box is the nearest intervention to
+    # the observed mean that the bounds allow, which is what "shrink towards
+    # what was done before" can mean when what was done before is off-limits
+    # now. A user-supplied prev_recommended_interventions needs no projection:
+    # validate_inputs() already rejects one outside the bounds.
+    shrink_to_int_values <- pmin(
+      pmax(observed_mean_int_values, intervention_lower_bounds),
+      intervention_upper_bounds
     )
   } else {
     shrink_to_int_values <- prev_recommended_interventions
@@ -292,14 +359,7 @@ get_recommended_interventions <- function(
         est_rec_int <- as.numeric(full_grid[best_index, ])
         rec_int_cost <- all_costs[best_index]
       } else {
-        warning(paste(
-          "The outcome goal is not estimated to be achievable.",
-          "Since the maximum estimated achievable outcome\n",
-          "is less than the outcome goal, we will shrink",
-          "the recommended intervention towards the\n",
-          "recommended intervention from the previous stage.",
-          collapse = " "
-        ))
+        warning(unachievable_goal_message(lower_outcome_goal))
         shrinking_results <- shrinking_method(
           lo = lo,
           up = up,
@@ -549,14 +609,7 @@ get_recommended_interventions <- function(
           center_cha = center_cha
         )
       } else {
-        warning(paste(
-          "The outcome goal is not estimated to be achievable.",
-          "Since the maximum estimated achievable outcome\n",
-          "is less than the outcome goal, we will shrink",
-          "the recommended intervention towards the\n",
-          "recommended intervention from the previous stage.",
-          collapse = " "
-        ))
+        warning(unachievable_goal_message(lower_outcome_goal))
 
         shrinking_results <- shrinking_method(
           lo = lo,
@@ -642,9 +695,10 @@ get_recommended_interventions <- function(
     # the effective outcome goal actually used for optimization:
     # max(power-implied outcome, outcome_goal). Equals outcome_goal when
     # no power goal is set, and the power-implied outcome when only a
-    # power goal is set. Reported on the original outcome scale, like
-    # est_reachable_outcome above and through the same un-flip, so downstream
-    # consumers such as the confidence set and printout can use it directly.
-    effective_outcome_goal = un_flip(new_outcome_goal)
+    # power goal is set. Already on the original outcome scale: it is the value
+    # the flip above was applied TO, so it is reported exactly as the caller
+    # stated it rather than un-flipped back, and downstream consumers such as
+    # the confidence set and the printout can use it directly.
+    effective_outcome_goal = effective_outcome_goal
   ))
 }

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -524,8 +524,12 @@ get_recommended_interventions <- function(
           ))
         }
 
+        # cost_results holds the cost each restart converged to, so the best
+        # restart is the cheapest one. Every restart satisfies the outcome
+        # constraint, which solnl() enforces through confun, so choosing among
+        # them is purely a matter of cost.
         valid_indices <- which(!is.na(cost_results))
-        min_position <- valid_indices[which.max(cost_results[valid_indices])]
+        min_position <- valid_indices[which.min(cost_results[valid_indices])]
         rec_int_cost <- cost_results[min_position]
         int_components <- results_int_components[, min_position]
 

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -62,7 +62,8 @@
 #' Default value without user specification:
 #' 1/20 of the range for each intervention component.
 #' @param link A character string. Specifies the link function used when fitting
-#' the outcome model.
+#' the outcome model, either "logit" or "identity". These are the only links the
+#' outcome machinery implements, see supported_outcome_links().
 #' @param lower_outcome_goal A boolean value. Specifies whether the outcome goal
 #' is intended to be lower or higher than the average outcome.
 #' @param prev_recommended_interventions A numeric vector. Specifies the

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -343,11 +343,10 @@ get_recommended_interventions <- function(
       return(list(
         est_rec_int = est_rec_int,
         rec_int_cost = rec_int_cost,
-        est_reachable_outcome = ifelse(
-          lower_outcome_goal,
-          -1 * est_reachable_outcome,
-          est_reachable_outcome
-        ),
+        # left on the flipped scale, like everything else this optimizer
+        # computes. It is put back on the original outcome scale once, at the
+        # single un-flip in this function's return value below.
+        est_reachable_outcome = est_reachable_outcome,
         shrinking_method_used = shrinking_method_used
       ))
     }
@@ -591,11 +590,10 @@ get_recommended_interventions <- function(
       return(list(
         est_rec_int = est_rec_int,
         rec_int_cost = rec_int_cost,
-        est_reachable_outcome = ifelse(
-          lower_outcome_goal,
-          -1 * est_reachable_outcome,
-          est_reachable_outcome
-        ),
+        # left on the flipped scale, like max_achievable_outcome and everything
+        # else this optimizer computes. It is put back on the original outcome
+        # scale once, at the single un-flip in this function's return below.
+        est_reachable_outcome = est_reachable_outcome,
         max_achievable_outcome = max_achievable_outcome,
         shrinking_method_used = shrinking_method_used
       ))
@@ -615,21 +613,33 @@ get_recommended_interventions <- function(
     )
   }
 
+  # THE scale boundary. Everything above works on the flipped outcome scale
+  # when lower_outcome_goal is TRUE (the "minimize" direction is implemented by
+  # negating the fitted coefficients, see lago_optimization()), and every
+  # caller below expects the original outcome scale. So the flip is undone
+  # here, once, for every outcome-valued field and on every path, rather than
+  # inside each optimizer. Each optimizer previously undid it for itself, with
+  # its own copy of the inverse, which is how the two came to disagree with the
+  # flip they were inverting.
+  #
+  # Only outcome-valued fields are un-flipped. est_rec_int and rec_int_cost are
+  # an intervention and its cost: they live on the intervention scale, which
+  # the flip never touched, so they pass through untouched.
+  un_flip <- function(value) {
+    if (lower_outcome_goal) flip_outcome_scale(value, link) else value
+  }
+
   return(list(
     est_rec_int = opt_results$est_rec_int,
     rec_int_cost = opt_results$rec_int_cost,
-    est_reachable_outcome = opt_results$est_reachable_outcome,
+    est_reachable_outcome = un_flip(opt_results$est_reachable_outcome),
     shrinking_method_used = opt_results$shrinking_method_used,
     # the effective outcome goal actually used for optimization:
     # max(power-implied outcome, outcome_goal). Equals outcome_goal when
     # no power goal is set, and the power-implied outcome when only a
-    # power goal is set. Reported on the original outcome scale (re-negated
-    # for the "minimize" case, mirroring est_reachable_outcome) so downstream
+    # power goal is set. Reported on the original outcome scale, like
+    # est_reachable_outcome above and through the same un-flip, so downstream
     # consumers such as the confidence set and printout can use it directly.
-    effective_outcome_goal = if (lower_outcome_goal) {
-      -1 * new_outcome_goal
-    } else {
-      new_outcome_goal
-    }
+    effective_outcome_goal = un_flip(new_outcome_goal)
   ))
 }

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -587,12 +587,40 @@ get_recommended_interventions <- function(
 
         # cost_results holds the cost each restart converged to, so the best
         # restart is the cheapest one. Every restart satisfies the outcome
-        # constraint, which solnl() enforces through confun, so choosing among
-        # them is purely a matter of cost.
-        valid_indices <- which(!is.na(cost_results))
+        # constraint, which solnl() enforces through confun, so cost is the only
+        # thing to choose on among the ones that are actually implementable.
+        #
+        # solnl() treats the box as a soft constraint and will step a little
+        # outside it to buy a lower objective, so the cheapest restart is
+        # systematically the one furthest outside the bounds: selecting on cost
+        # alone selects for the violation. Restarts that left the box are
+        # therefore dropped before the comparison. If every restart left it they
+        # are all kept, so a recommendation is still returned, and the result is
+        # brought back onto the box below.
+        in_box <- apply(
+          results_int_components, 2,
+          function(x) {
+            all(x >= intervention_lower_bounds) &&
+              all(x <= intervention_upper_bounds)
+          }
+        )
+        valid_indices <- which(!is.na(cost_results) & in_box)
+        if (length(valid_indices) == 0) {
+          valid_indices <- which(!is.na(cost_results))
+        }
         min_position <- valid_indices[which.min(cost_results[valid_indices])]
-        rec_int_cost <- cost_results[min_position]
         int_components <- results_int_components[, min_position]
+
+        # The chosen restart can still sit a solver tolerance outside the box,
+        # when every restart did. A recommendation has to be implementable, so
+        # it is brought back onto the bounds and its cost recomputed at the
+        # value actually being recommended rather than reported from the point
+        # the solver stopped at.
+        int_components <- pmin(
+          pmax(int_components, intervention_lower_bounds),
+          intervention_upper_bounds
+        )
+        rec_int_cost <- cost_obj_fun(int_components)
 
         est_rec_int <- int_components
 

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -380,6 +380,10 @@ lago_optimization <- function(
   # the two are not comparable and the goal constraint is meaningless. That map
   # is flip_outcome_scale(), which is a negation on a linear link but a
   # reflection about 1/2 on the logit link, where the outcome is a probability.
+  # It is applied inside get_recommended_interventions(), which is the function
+  # that works on the flipped scale, so the goal handed over here is the
+  # caller's own value and comes back out unchanged rather than as a value
+  # recovered by flipping a flipped copy.
   if (lower_outcome_goal) {
     new_model <- model
     new_model$coefficients <- -1 * (model$coefficients)
@@ -401,11 +405,7 @@ lago_optimization <- function(
     cost_list_of_vectors = cost_list_of_vectors,
     intervention_lower_bounds = intervention_lower_bounds,
     intervention_upper_bounds = intervention_upper_bounds,
-    outcome_goal = if (lower_outcome_goal) {
-      flip_outcome_scale(outcome_goal, link)
-    } else {
-      outcome_goal
-    },
+    outcome_goal = outcome_goal,
     center_characteristics_optimization_values =
       center_characteristics_optimization_values,
     time_effect_optimization_value = time_effect_optimization_value,

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -73,6 +73,9 @@
 #' Default value without user specification:
 #' "gaussian" for continuous outcomes, "binomial" for binary outcomes.
 #' @param link A character string. The link function of the glm() outcome model.
+#' Must be either "logit" or "identity": those are the links whose inverse the
+#' estimated outcome and the confidence set are computed with, so they are the
+#' only ones that can be reported on the outcome scale the goal is stated on.
 #' Default value without user specification:
 #' "identity" for continuous outcomes, "logit" for binary outcomes.
 #' @param weights A numeric vector. The weights argument of the glm()

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -370,6 +370,13 @@ lago_optimization <- function(
   list2env(outcome_model, envir = environment())
 
   if (!quiet) cli::cli_alert_info("Calculating the recommended intervention...")
+  # the "minimize" direction is implemented by negating the fitted
+  # coefficients, which turns "reach an outcome at most as large as the goal"
+  # into the maximization problem the optimizers already solve. The outcome
+  # goal has to be moved onto the same flipped scale, using the same map, or
+  # the two are not comparable and the goal constraint is meaningless. That map
+  # is flip_outcome_scale(), which is a negation on a linear link but a
+  # reflection about 1/2 on the logit link, where the outcome is a probability.
   if (lower_outcome_goal) {
     new_model <- model
     new_model$coefficients <- -1 * (model$coefficients)
@@ -391,7 +398,11 @@ lago_optimization <- function(
     cost_list_of_vectors = cost_list_of_vectors,
     intervention_lower_bounds = intervention_lower_bounds,
     intervention_upper_bounds = intervention_upper_bounds,
-    outcome_goal = if (lower_outcome_goal) -1 * outcome_goal else outcome_goal,
+    outcome_goal = if (lower_outcome_goal) {
+      flip_outcome_scale(outcome_goal, link)
+    } else {
+      outcome_goal
+    },
     center_characteristics_optimization_values =
       center_characteristics_optimization_values,
     time_effect_optimization_value = time_effect_optimization_value,

--- a/R/shrinking_method.R
+++ b/R/shrinking_method.R
@@ -104,10 +104,46 @@ shrinking_method <- function(
 
     beta_max <- left
 
-    # Calculate beta min and recommended value
+    # beta_max is the coefficient this component would need, at its upper
+    # bound, to reach the outcome goal on its own. The recommendation is an
+    # interpolation between the two ENDPOINTS below, indexed by how far
+    # beta_vec[c] has travelled along [beta_min, beta_max]:
+    #
+    #   beta_vec[c] == beta_min  ->  stage_1_intervention[c]
+    #   beta_vec[c] == beta_max  ->  up[c]
+    #
+    # (substitute either into the interpolation and it returns exactly that
+    # endpoint). Both endpoints are inside [lo, up]: up[c] is a bound, and the
+    # stage-1 intervention is one too, since a user-supplied
+    # prev_recommended_interventions is validated against the bounds and the
+    # colMeans() default it falls back to is projected onto them. So the
+    # interpolation stays inside the bounds exactly as long as its fraction
+    # stays in [0, 1], i.e. as long as beta_vec[c] stays inside the bracket,
+    # and that is what the three branches below enforce.
+    #
+    # beta_min = beta_max / 2 is "half as effective as needed", which only
+    # brackets beta_max from below while beta_max > 0. Under the "minimize"
+    # direction the fitted coefficients are negated (see lago_optimization()),
+    # so beta_max is routinely <= 0: halving it then moves it AWAY from zero's
+    # side and the bracket is empty or inverted, beta_max - beta_min <= 0. The
+    # interpolation has no meaning on an empty bracket -- with a negative width
+    # it runs backwards, away from up[c] and out through lo[c], and with a zero
+    # width it divides by zero and returns a non-finite intervention. There is
+    # no fraction to compute in that case, so the fallback the caller warned
+    # about, the stage-1 intervention itself, is what is returned. This is
+    # decided from the bracket the binary search produced rather than from the
+    # sign of any coefficient, so it does not depend on the optimization
+    # direction: an inverted bracket is refused the same way whichever
+    # direction produced it.
     beta_min <- beta_max / 2
-    if (beta_vec[c] <= beta_min) {
+    if (beta_max - beta_min <= 0 || beta_vec[c] <= beta_min) {
+      # at or below the bottom of the bracket, or no usable bracket at all
       recommended_values[c] <- stage_1_intervention[c]
+    } else if (beta_vec[c] >= beta_max) {
+      # at or above the top of the bracket. The interpolation's value at
+      # beta_max is up[c], and extrapolating past it would recommend more of
+      # the component than the upper bound allows.
+      recommended_values[c] <- up[c]
     } else {
       slope <- (up[c] - stage_1_intervention[c]) / (beta_max - beta_min)
       recommended_values[c] <- stage_1_intervention[c] +

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -135,16 +135,21 @@ validate_inputs <- function(
   if (!is.character(link)) {
     stop("The link option must be a character string.")
   }
-  # check if the provided link option is supported
-  supported_link_options <- c("logit", "probit", "identity", "log", "default")
+  # check if the provided link option is supported. The set is
+  # supported_outcome_links(), the one place the links the outcome machinery
+  # implements are written down, plus "default", which is resolved to one of
+  # them from the glm family just below.
+  # "probit" and "log" used to be accepted here and are not any more. Nothing
+  # implemented their inverse links, so get_outcome() fell through to its
+  # identity branch and reported the LINEAR PREDICTOR as the estimated
+  # probability or mean: a probit fit asked to hold the outcome at most 0.20
+  # reported 0.200 as reached while the actual probability was pnorm(0.20) =
+  # 0.579, and get_confidence_set() built its interval on the wrong scale too.
+  # Accepting a link only some of the machinery handles reports wrong numbers
+  # with no sign anything is wrong, so the link is refused up front instead.
+  supported_link_options <- c(supported_outcome_links(), "default")
   if (!(link %in% supported_link_options)) {
-    stop(paste(
-      "link=", link, ".",
-      paste0(
-        "The link option has to be one of ",
-        "the following: logit, probit, identity, and log."
-      )
-    ))
+    stop(unsupported_link_message(link))
   }
   # assign link based on the glm_family
   if (link == "default") {

--- a/man/get_confidence_set.Rd
+++ b/man/get_confidence_set.Rd
@@ -70,7 +70,9 @@ of interest.}
 
 \item{fitted_model}{A glm(). The fitted glm() outcome model.}
 
-\item{link}{A character string. The link function (e.g. "logit", "identity").}
+\item{link}{A character string. The link function the interval is computed
+on, either "logit" or "identity". These are the only links the outcome
+machinery implements, see supported_outcome_links().}
 
 \item{outcome_goal}{A numeric value. Specifies the outcome goal, a desired
 probability or mean value.}

--- a/man/get_recommended_interventions.Rd
+++ b/man/get_recommended_interventions.Rd
@@ -108,7 +108,8 @@ center_characteristics.
 For example: c(1.75)}
 
 \item{link}{A character string. Specifies the link function used when fitting
-the outcome model.}
+the outcome model, either "logit" or "identity". These are the only links the
+outcome machinery implements, see supported_outcome_links().}
 
 \item{lower_outcome_goal}{A boolean value. Specifies whether the outcome goal
 is intended to be lower or higher than the average outcome.}

--- a/man/lago_optimization.Rd
+++ b/man/lago_optimization.Rd
@@ -169,6 +169,9 @@ Default value without user specification:
 "gaussian" for continuous outcomes, "binomial" for binary outcomes.}
 
 \item{link}{A character string. The link function of the glm() outcome model.
+Must be either "logit" or "identity": those are the links whose inverse the
+estimated outcome and the confidence set are computed with, so they are the
+only ones that can be reported on the outcome scale the goal is stated on.
 Default value without user specification:
 "identity" for continuous outcomes, "logit" for binary outcomes.}
 


### PR DESCRIPTION
## Fix `minimize` ignoring the outcome goal, and the recommendation leaving its bounds

  Started as the two defects deferred from #68. Root-cause analysis found the
  first was much larger than reported, and review found four more.

  ### `minimize` was inverting its own transform with the wrong function

  `outcome_goal_intention = "minimize"` negates the model's coefficients and
  maximizes the flipped problem. For a logit link that maps `p` to `1 - p`, not to
  `-p`, and both optimizers inverted it with `-1 *`.

  The reported estimate was `-(1 - p)`: on the bundled data `-0.5218337` where the
  estimate is `0.4781663`, printed directly above a CI of `0.444 0.512`. The
  serious part was invisible: the goal handed to the optimization was negated
  while the quantity it constrains stays in (0,1), so the constraint read
  `p >= -0.55` and held for every candidate. **The minimize goal was inert** —
  goals of 0.55, 0.30 and 0.10 returned identical recommendations. On a
  constructed feasible case the optimizer returned the do-nothing intervention at
  zero cost, true probability 0.94, reported as meeting a goal of 0.5 or below.
  Unachievable goals were never detected, so the shrinking path was unreachable.

  The transform and its inverse are now one function applied once in each
  direction, so they cannot disagree.

  ### The recommendation could leave the bounds the user supplied

  The shrinking method interpolates between two in-box endpoints, but its bracket
  `beta_min <- beta_max/2` only contains `beta_max` while that is positive, so the
  fraction was not confined to [0,1]. Three failure modes, only the first specific
  to minimize: below the lower bound, non-finite, and past the upper bound.
  Reachable on `main` in the **maximize** direction with no power goal: a goal of 1
  returns `Inf`, and with lower bounds of 10 it returns `-23.3`.

  ### Four more, found in review

  - `probit` and `log` passed validation and were documented as supported, but the
    outcome calculation only implemented `logit` and `identity` and returned the
    linear predictor as a probability. Asking for `<= 0.20` under `probit`
    reported exactly `0.200000`; the true probability is `0.579`. Both are now
    rejected: `log`'s minimize inverse is not a function of the outcome value at
    all, and `probit` needs variance paths the confidence set does not have.
  - The numerical optimizer returned the **most expensive** of its restarts
    (`which.max` assigned to a variable named `min_position`).
  - Fixing that introduced a regression a reviewer caught: the cheapest restart is
    cheapest *because* it sits outside the box, so selecting on cost selects for
    the violation. Out-of-box restarts are now dropped before the comparison.
  - `get_outcome()` left one linear-predictor term unsummed, so 2+ center
    characteristics recycled a vector.
