### PR TITLE
Fix/optimizer and weight validation gaps

### DIFF
--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -259,10 +259,13 @@ get_confidence_set <- function(
   # its own name, which is what the checks below then report as unmatched.
   coef_mapping <- term_coef_names(fitted_model)
   model_coef_names <- names(coef(fitted_model))
-  # every name the assembly below can supply for itself, set aside so the
-  # fallback in fixed_effect_coef_names() does not take a covariate whose own
-  # name begins with "center" or "period" for a fixed-effect dummy.
-  named_predictors <- gsub("`", "", c(
+  # every COEFFICIENT name the assembly below can supply for itself, set aside
+  # so the fallback in fixed_effect_coef_names() does not take a covariate
+  # whose own name begins with "center" or "period" for a fixed-effect dummy.
+  # Coefficient names and not column names: a factor covariate's coefficient is
+  # named after its level, so center_grp on its own never held back
+  # center_grpb. See claimed_coef_names().
+  named_predictors <- claimed_coef_names(fitted_model, coef_mapping, c(
     "(Intercept)", intervention_components, additional_covariates,
     center_characteristics
   ))
@@ -1017,6 +1020,14 @@ predictor_coef_names <- function(predictor, coef_mapping) {
 # search this used to do, restricted to the coefficients no other block can
 # claim so that a covariate named like center_size or period_flag is not
 # taken for a dummy.
+#
+# named_predictors is the COEFFICIENT names the callers claim, not the column
+# names, which is what claimed_coef_names() builds for them. Excluding by
+# column name only excluded a numeric predictor, whose single coefficient is
+# named after the column; a factor or character predictor is one coefficient
+# per non-reference level, named after the LEVEL, so center_grp in the list
+# never excluded its coefficient center_grpb and the anchored search below
+# claimed it as a center dummy.
 fixed_effect_coef_names <- function(term,
                                     coef_mapping,
                                     model_coef_names,
@@ -1029,6 +1040,60 @@ fixed_effect_coef_names <- function(term,
     !gsub("`", "", model_coef_names) %in% named_predictors
   ]
   grep(paste0("^", term), unclaimed, value = TRUE, ignore.case = TRUE)
+}
+
+# every coefficient name the caller's own named predictors account for, which
+# is what fixed_effect_coef_names() must not claim as a fixed center or time
+# effect. Both callers hold the same thing back: the intercept, the
+# intervention components, the additional covariates and the center
+# characteristics.
+#
+# A predictor's coefficient names are NOT in general its column name. glm()
+# expands a factor or character column into one dummy per non-reference level
+# and names each dummy after the level, so a column center_grp with levels a/b
+# is a coefficient named center_grpb. Passing the column names alone therefore
+# held back nothing for such a column, and its coefficient was claimed as a
+# center dummy: all_center_lvl_effects came back one entry too long, the
+# weights recycled against it, and the reported outcome was wrong by 5% with no
+# indication. That is #68's defect on a factor covariate, and it is the reason
+# this expansion exists rather than the raw names being passed.
+#
+# The expansion is done in two ways because the two apply in disjoint cases.
+# predictor_coef_names() is exact and is used whenever the term mapping is
+# available. It cannot help when the mapping is NULL, since it then returns the
+# column name unchanged -- and NULL is exactly when fixed_effect_coef_names()
+# consults this list at all. So for that case the levels the model was fitted
+# on are used instead: model$xlevels records them per column and survives a
+# model = FALSE fit whose data has left scope, which is one way a mapping goes
+# missing, and glm() names the dummy of each non-reference level
+# paste0(column, level). Both level sets and both namings come from the model
+# itself, so no name is guessed from its shape.
+#
+# Both expansions are unioned with the raw column names rather than replacing
+# them: a numeric column IS its own coefficient name, a column the model does
+# not treat as a factor has no xlevels entry, and holding back a name the model
+# has no coefficient for costs nothing.
+claimed_coef_names <- function(model, coef_mapping, named_predictors) {
+  columns <- gsub("`", "", named_predictors)
+  xlevels <- model$xlevels
+  level_names <- unlist(
+    lapply(columns, function(column) {
+      levels <- xlevels[[column]]
+      if (length(levels) < 2) {
+        character(0)
+      } else {
+        # the reference level has no dummy of its own: glm() leaves it out and
+        # the intercept carries it
+        paste0(column, levels[-1])
+      }
+    }),
+    use.names = FALSE
+  )
+  mapped_names <- unlist(
+    lapply(columns, predictor_coef_names, coef_mapping),
+    use.names = FALSE
+  )
+  unique(c(columns, level_names, mapped_names))
 }
 
 # the coefficient name each center characteristic stands for, one per

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -1048,52 +1048,111 @@ fixed_effect_coef_names <- function(term,
 # intervention components, the additional covariates and the center
 # characteristics.
 #
-# A predictor's coefficient names are NOT in general its column name. glm()
-# expands a factor or character column into one dummy per non-reference level
-# and names each dummy after the level, so a column center_grp with levels a/b
-# is a coefficient named center_grpb. Passing the column names alone therefore
-# held back nothing for such a column, and its coefficient was claimed as a
-# center dummy: all_center_lvl_effects came back one entry too long, the
-# weights recycled against it, and the reported outcome was wrong by 5% with no
-# indication. That is #68's defect on a factor covariate, and it is the reason
-# this expansion exists rather than the raw names being passed.
+# A predictor's coefficient names are NOT in general its column name. A column
+# the model contrast-codes carries one coefficient per contrast column, named
+# after that contrast column and not after the term, so a column center_grp
+# with levels a/b is a coefficient named center_grpb. Passing the column names
+# alone therefore held back nothing for such a column, and its coefficient was
+# claimed as a center dummy: all_center_lvl_effects came back one entry too
+# long, the weights recycled against it, and the reported outcome was wrong by
+# 5% with no indication. That is #68's defect on a factor covariate, and it is
+# the reason this expansion exists rather than the raw names being passed.
 #
 # The expansion is done in two ways because the two apply in disjoint cases.
 # predictor_coef_names() is exact and is used whenever the term mapping is
 # available. It cannot help when the mapping is NULL, since it then returns the
 # column name unchanged -- and NULL is exactly when fixed_effect_coef_names()
-# consults this list at all. So for that case the levels the model was fitted
-# on are used instead: model$xlevels records them per column and survives a
-# model = FALSE fit whose data has left scope, which is one way a mapping goes
-# missing, and glm() names the dummy of each non-reference level
-# paste0(column, level). Both level sets and both namings come from the model
-# itself, so no name is guessed from its shape.
+# consults this list at all. So for that case the coding the model was fitted
+# under is used instead, via contrast_coef_names() below, which reads it off
+# model$contrasts and model$xlevels. Both survive a fit made with
+# model = FALSE whose data= name has since left scope, which is one way a
+# mapping goes missing: model = FALSE alone leaves the mapping intact, since
+# model.matrix() re-derives the frame from the data that is still reachable.
 #
 # Both expansions are unioned with the raw column names rather than replacing
-# them: a numeric column IS its own coefficient name, a column the model does
-# not treat as a factor has no xlevels entry, and holding back a name the model
-# has no coefficient for costs nothing.
-claimed_coef_names <- function(model, coef_mapping, named_predictors) {
+# them: a numeric column IS its own coefficient name, so it is not
+# contrast-coded and has no $contrasts entry to expand.
+claimed_coef_names <- function(model, coef_mapping, named_predictors,
+                               fixed_effect_terms = c("center", "period")) {
   columns <- gsub("`", "", named_predictors)
-  xlevels <- model$xlevels
-  level_names <- unlist(
-    lapply(columns, function(column) {
-      levels <- xlevels[[column]]
-      if (length(levels) < 2) {
-        character(0)
-      } else {
-        # the reference level has no dummy of its own: glm() leaves it out and
-        # the intercept carries it
-        paste0(column, levels[-1])
-      }
-    }),
+  # A column named exactly like a fixed-effect term is dropped rather than
+  # resolved. Its dummies would be named paste0("center", level), which is how
+  # the real center dummies are named, so nothing distinguishes them once the
+  # term mapping is gone: holding them back would take every genuine dummy with
+  # them and leave the fixed effects empty, which is worse than the
+  # over-claiming this list prevents. Leaving such a column out means the search
+  # below over-claims by exactly its coefficients, which the caller's
+  # coefficient count check then refuses, so the collision is reported instead
+  # of silently resolved either way.
+  columns <- setdiff(columns, fixed_effect_terms)
+  contrast_names <- unlist(
+    lapply(columns, contrast_coef_names, model),
     use.names = FALSE
   )
   mapped_names <- unlist(
     lapply(columns, predictor_coef_names, coef_mapping),
     use.names = FALSE
   )
-  unique(c(columns, level_names, mapped_names))
+  unique(c(columns, contrast_names, mapped_names))
+}
+
+# the coefficient names one column of the fitted model was contrast-coded into,
+# derived from the coding the model itself records rather than from a naming
+# convention. Empty for a column the model did not contrast-code at all, e.g. a
+# numeric one, whose single coefficient is its own column name.
+#
+# The names are not reconstructed from the levels. glm() names a dummy
+# paste0(column, level) only under contr.treatment, and three supported column
+# types are coded some other way:
+#   - an ordered factor defaults to contr.poly, giving center_ord.L and
+#     center_ord.Q rather than one dummy per level;
+#   - a logical column is contrast-coded as a two-level factor FALSE/TRUE
+#     (center_flagTRUE) but gets NO $xlevels entry, so a levels-driven
+#     expansion saw fewer than two levels and held nothing back at all;
+#   - a caller may set any coding through options(contrasts=) or the per-column
+#     contrasts= argument of glm(), and contr.sum, contr.helmert and an unnamed
+#     contrast matrix all name their dummies by POSITION: center_grp1,
+#     center_grp2.
+# Each of those was a name the model has and this function did not report, so
+# the anchored search in fixed_effect_coef_names() claimed it as a center or
+# period dummy: the #68 recycling shape, silently wrong by 10.5% on the
+# ordered case.
+#
+# model$contrasts is the slot R records the coding in. It names every
+# contrast-coded column, logicals included, and holds either the name of the
+# contrast function or the contrast matrix itself. stats::contrasts() resolves
+# either to the matrix, and its colnames() are the suffixes glm() appends --
+# NULL colnames meaning the columns are numbered from 1, which is what
+# model.matrix() does with them. The factor is rebuilt from the model's own
+# levels with the recorded coding attached, so the answer depends on the fit
+# and not on the caller's current options(contrasts=).
+contrast_coef_names <- function(column, model) {
+  contrast <- model$contrasts[[column]]
+  if (is.null(contrast)) {
+    return(character(0))
+  }
+  # a logical column is coded as the two-level factor factor(x, c(FALSE, TRUE))
+  # and so has no $xlevels entry of its own to read
+  levels <- model$xlevels[[column]]
+  if (is.null(levels)) {
+    levels <- c("FALSE", "TRUE")
+  }
+  matrix <- tryCatch(
+    {
+      rebuilt <- factor(levels, levels = levels)
+      attr(rebuilt, "contrasts") <- contrast
+      stats::contrasts(rebuilt)
+    },
+    error = function(e) NULL
+  )
+  if (!is.matrix(matrix) || ncol(matrix) == 0) {
+    return(character(0))
+  }
+  suffixes <- colnames(matrix)
+  if (is.null(suffixes)) {
+    suffixes <- as.character(seq_len(ncol(matrix)))
+  }
+  paste0(column, suffixes)
 }
 
 # the coefficient name each center characteristic stands for, one per

--- a/R/get_confidence_set.R
+++ b/R/get_confidence_set.R
@@ -1125,7 +1125,20 @@ claimed_coef_names <- function(model, coef_mapping, named_predictors,
 # NULL colnames meaning the columns are numbered from 1, which is what
 # model.matrix() does with them. The factor is rebuilt from the model's own
 # levels with the recorded coding attached, so the answer depends on the fit
-# and not on the caller's current options(contrasts=).
+# and not on the caller's current options(contrasts=). The levels have to be
+# carried over rather than left to factor(), which would sort them: under the
+# default coding the suffixes ARE the levels, so a re-sorted rebuild names a
+# dummy the model does not have.
+#
+# What this cannot do is tell whose coefficient a name belongs to. It appends a
+# suffix to a column name, and the resulting string can be spelled the same as
+# a coefficient of another term: a column "cent" with a level "erKakiri HC III"
+# gives "centerKakiri HC III", the name of a real center dummy, and on the
+# fallback that dummy is then held back from the center effects. The case that
+# is actually reachable, a column named exactly like a fixed-effect term, is
+# handled by claimed_coef_names() above. The rest is the residual ambiguity of
+# looking coefficients up by name at all, which is why this path exists only
+# for models whose own term mapping is gone.
 contrast_coef_names <- function(column, model) {
   contrast <- model$contrasts[[column]]
   if (is.null(contrast)) {

--- a/R/get_recommended_interventions.R
+++ b/R/get_recommended_interventions.R
@@ -30,6 +30,52 @@ unachievable_goal_message <- function(lower_outcome_goal) {
 }
 
 
+#' refuse_if_all_restarts_failed
+#'
+#' @description Internal guard for a multi-start numerical optimization in
+#' which EVERY restart failed, so there is no result among them to choose
+#' from.
+#'
+#' @details Both restart loops of the numerical optimizer record a failed
+#' NlcOptim::solnl() call as NA and carry on, so that one bad starting point
+#' does not lose the whole optimization. All of them failing is a different
+#' situation: there is nothing to select, and the only thing to tell the
+#' caller is that this optimizer could not solve their problem and which one
+#' can.
+#'
+#' The condition and the message live here, once, rather than at each loop.
+#' The max-achievable-outcome loop had no such check at all while the cost loop
+#' had one, and the difference was not visible as a difference: an all-failed
+#' max-outcome loop reached `which.max()` over all NAs, which is `integer(0)`,
+#' so the outcome it indexed was `numeric(0)` and the goal comparison two
+#' statements later failed with the R error "argument is of length zero". One
+#' guard both loops call is what stops a third loop from being written without
+#' one, and what keeps a single wording for a single situation.
+#'
+#' @param results A numeric vector, one entry per restart, holding the value
+#' that restart converged to. NA marks a restart whose optimization failed.
+#'
+#' @return Invisibly NULL when at least one restart succeeded. Raises
+#' otherwise, so the callers below can treat returning as "there is something
+#' to choose from".
+#'
+#' @noRd
+refuse_if_all_restarts_failed <- function(results) {
+  if (all(is.na(results))) {
+    stop(paste(
+      "Numerical optimization failed to find a solution.",
+      "Please consider using the 'grid_search' method by",
+      "setting the 'optimization_method' parameter to",
+      "'grid_search', and provide proper values for the",
+      "'optimization_grid_search_step_size' parameter.",
+      "This problem usually occurs when you have more than",
+      "three intervention components."
+    ))
+  }
+  invisible(NULL)
+}
+
+
 #' select_restart_within_bounds
 #'
 #' @description Internal function that picks the recommended intervention out
@@ -581,6 +627,15 @@ get_recommended_interventions <- function(
           results[i] <- NA # Assign NA if the optimization failed
         }
       }
+      # every restart having failed is refused here, before anything is read
+      # out of results. which.max() over an all-NA vector is integer(0), so
+      # the outcome below would be numeric(0) and the goal comparison further
+      # down would fail with "argument is of length zero" instead of saying
+      # what went wrong. Some restarts failing is not this case and is handled
+      # by which.max() itself, which skips NAs: the surviving restarts are
+      # compared and the winner's column of results_int_components is the
+      # column that same restart wrote, since both are indexed by restart.
+      refuse_if_all_restarts_failed(results)
       max_position <- which.max(results)
       max_achievable_outcome <- results[max_position]
 
@@ -652,18 +707,10 @@ get_recommended_interventions <- function(
           }
         }
 
-        # if numerical solution fails to find a solution
-        if (all(is.na(cost_results))) {
-          stop(paste(
-            "Numerical optimization failed to find a solution.",
-            "Please consider using the 'grid_search' method by",
-            "setting the 'optimization_method' parameter to",
-            "'grid_search', and provide proper values for the",
-            "'optimization_grid_search_step_size' parameter.",
-            "This problem usually occurs when you have more than",
-            "three intervention components."
-          ))
-        }
+        # if numerical solution fails to find a solution. The same refusal the
+        # max-outcome loop above makes, from the same place, so the two loops
+        # cannot come to describe the same situation differently.
+        refuse_if_all_restarts_failed(cost_results)
 
         # Choosing among the restarts, and making the winner implementable, is
         # one decision and lives in select_restart_within_bounds(): the in-box

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -126,7 +126,8 @@
 #' @param  center_weights_for_outcome_goal A numeric vector. Specifies the
 #' weights that will be used for calculating recommended interventions that
 #' satisfy the outcome goal for an (weighted) average center.
-#' The weights need to sum up to 1.
+#' The weights need to sum up to 1, and must all be non-negative and finite.
+#' A weight of 0 is allowed and excludes that center from the average.
 #' Default value without user specification:
 #' For each center, calculate what percentage its sample size is of the total
 #' samples across all facilities - this percentage serves as that

--- a/R/rec_int_processor.R
+++ b/R/rec_int_processor.R
@@ -85,10 +85,13 @@ rec_int_processor <- function(
   # The fallback for a model whose term mapping could not be rebuilt is the name
   # search this used to do, anchored so that only a name beginning with the term
   # is matched, and restricted to the coefficients no other block below claims
-  # for itself. It is reachable: a model fitted with model = FALSE whose data
-  # has since left scope cannot rebuild its mapping, and the exported
-  # get_confidence_set() accepts any model the caller passes, so the fallback is
-  # what a caller in that position gets rather than dead code.
+  # for itself. It is reachable: a model fitted with model = FALSE cannot
+  # rebuild its mapping once the name it was given as data= has left scope, so
+  # model.matrix() has neither a frame to read nor data to re-derive one from.
+  # model = FALSE alone leaves the mapping intact, since the data is still
+  # reachable. The exported get_confidence_set() accepts any model the caller
+  # passes, so the fallback is what a caller in that position gets rather than
+  # dead code.
   #
   # That exclusion list is the point of named_predictors, and it has to be the
   # names THIS function looks up on its own account, exactly as

--- a/R/rec_int_processor.R
+++ b/R/rec_int_processor.R
@@ -100,7 +100,13 @@ rec_int_processor <- function(
   # adds its coefficient to all_center_lvl_effects and makes that vector one
   # longer than center_weights_for_outcome_goal, which shifts every predicted
   # outcome and recycles the weights: the #68 defect, one layer down.
-  named_predictors <- gsub("`", "", c(
+  #
+  # The list is the COEFFICIENT names those columns account for, which
+  # claimed_coef_names() resolves against the model. Passing the raw column
+  # names held back only the numeric ones: a factor or character covariate's
+  # coefficient is named after its level, so center_grp never held back
+  # center_grpb and the same #68 shape came back on the factor case alone.
+  named_predictors <- claimed_coef_names(model, coef_mapping, c(
     "(Intercept)", intervention_components, additional_covariates,
     center_characteristics
   ))

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -393,7 +393,7 @@ validate_inputs <- function(
     # refusing that would contradict allowing a weight of exactly 0. Anything
     # further below zero than rounding explains is a weight the caller meant to
     # be negative.
-    if (any(center_weights_for_outcome_goal < -sqrt(.Machine$double.eps))) {
+    if (any(center_weights_for_outcome_goal < -8 * .Machine$double.eps)) {
       stop(paste(
         "values in center_weights_for_outcome_goal must be non-negative.",
         "The weights average the per-center outcomes, so a negative weight",

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -387,7 +387,13 @@ validate_inputs <- function(
     # weights being 0 is a different matter, and it is already refused by the
     # sum check below, which is what keeps the renormalisation from dividing by
     # zero: a vector summing to 0 is 1 away from 1, not within 0.001 of it.
-    if (any(center_weights_for_outcome_goal < 0)) {
+    # Compared against a small negative tolerance rather than against 0. A
+    # weight a caller computes as a residual, one minus the others, can land a
+    # few floating-point units below zero while the vector still sums to 1, and
+    # refusing that would contradict allowing a weight of exactly 0. Anything
+    # further below zero than rounding explains is a weight the caller meant to
+    # be negative.
+    if (any(center_weights_for_outcome_goal < -sqrt(.Machine$double.eps))) {
       stop(paste(
         "values in center_weights_for_outcome_goal must be non-negative.",
         "The weights average the per-center outcomes, so a negative weight",

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -346,8 +346,56 @@ validate_inputs <- function(
     }
   }
 
-  # check if values of center_weights_for_outcome_goal sum up to 1
+  # check the values of center_weights_for_outcome_goal. Here rather than in the
+  # branch above that reads them from the caller, so that the checks cover every
+  # way the vector can be arrived at: the caller's weights, the center-size
+  # default and the single-named-center indicator alike. The center-size default
+  # is not automatically a set of weights either -- with every
+  # center_sample_size zero it is 0/0, i.e. all NaN.
   if (!is.null(center_weights_for_outcome_goal)) {
+    # every weight has to be a number before either of the checks that follow
+    # can be made at all: any(NA < 0) is not FALSE, it is the R error "missing
+    # value where TRUE/FALSE needed", and that is what a missing weight used to
+    # surface as at the sum check below. An Inf was refused there, but for
+    # summing to Inf rather than for being one, and an Inf beside a -Inf sums to
+    # NaN and hit the same opaque comparison. None of these is a weight, so each
+    # is named here instead.
+    if (!all(is.finite(center_weights_for_outcome_goal))) {
+      stop(paste(
+        "values in center_weights_for_outcome_goal must all be finite",
+        "numbers. NA, NaN, Inf and -Inf are not weights. If the weights were",
+        "not supplied, they were derived from the 'center_sample_size'",
+        "column, which cannot be zero for every center."
+      ))
+    }
+    # the weights are a convex combination over the centers: the reported
+    # outcome is sum(weight_i * outcome_i) over the center-level effects, so it
+    # is a weighted MEAN of the per-center outcomes and has to lie between the
+    # smallest and the largest of them. A negative weight breaks exactly that,
+    # and summing to 1 does not rule one out: weights of -10 and 11 sum to 1 and
+    # gave 10.95 for a logit outcome, i.e. a reported "probability" outside
+    # [0, 1] for a binary outcome. That is a wrong number rather than an error,
+    # so it is refused here and not clamped: a caller who passed a negative
+    # weight did not mean a weight of 0, and quietly substituting one would
+    # answer a question they did not ask.
+    #
+    # A weight of exactly 0 is allowed, deliberately. It means a center the
+    # recommendation is not being computed for, which is a meaningful thing to
+    # ask for and is what the package itself builds from
+    # center_effects_optimization_values: the named center gets weight 1 and
+    # every other center 0. Refusing 0 would refuse that documented path. All
+    # weights being 0 is a different matter, and it is already refused by the
+    # sum check below, which is what keeps the renormalisation from dividing by
+    # zero: a vector summing to 0 is 1 away from 1, not within 0.001 of it.
+    if (any(center_weights_for_outcome_goal < 0)) {
+      stop(paste(
+        "values in center_weights_for_outcome_goal must be non-negative.",
+        "The weights average the per-center outcomes, so a negative weight",
+        "makes the reported outcome fall outside the range of the outcomes it",
+        "averages, and for a binary outcome outside [0, 1]. A weight of 0 is",
+        "allowed and excludes that center from the average."
+      ))
+    }
     weights_sum <- sum(center_weights_for_outcome_goal)
     if (abs(weights_sum - 1) >= 0.001) {
       stop(paste(

--- a/man/lago_optimization.Rd
+++ b/man/lago_optimization.Rd
@@ -226,7 +226,8 @@ For example: c("component2xcomponent4").}
 \item{center_weights_for_outcome_goal}{A numeric vector. Specifies the
 weights that will be used for calculating recommended interventions that
 satisfy the outcome goal for an (weighted) average center.
-The weights need to sum up to 1.
+The weights need to sum up to 1, and must all be non-negative and finite.
+A weight of 0 is allowed and excludes that center from the average.
 Default value without user specification:
 For each center, calculate what percentage its sample size is of the total
 samples across all facilities - this percentage serves as that

--- a/tests/testthat/test-optimization.R
+++ b/tests/testthat/test-optimization.R
@@ -232,3 +232,130 @@ test_that("weights length is validated against the number of observations, not c
     "number of observations"
   )
 })
+
+
+test_that("an unsolvable numerical optimization says to use grid_search", {
+  # END TO END, which is what the unit test of the guard cannot show: that a
+  # configuration a user can actually pass reaches it. Every solnl() restart of
+  # the max-achievable-outcome loop fails on this fit, and the loop records each
+  # failure as NA. With all of them NA, which.max() is integer(0), the outcome
+  # read out of it is numeric(0), and the goal comparison that follows used to
+  # fail with the base-R error "argument is of length zero" -- no mention of the
+  # optimizer, the goal, or what to do instead. The cost loop 60 lines further
+  # down already refused the same situation with a message naming grid_search;
+  # this path simply never reached it.
+  #
+  # What makes every restart fail here: 6 recycled centers against 3 recycled
+  # periods are ALIASED (6 and 3 share a factor, so the period indicators are
+  # linear combinations of the center ones), glm() returns NA for the aliased
+  # period coefficients, and those NAs flow into the center-level effects. Every
+  # outcome the solver is asked for is then NA, so every restart fails. That is
+  # a rank-deficient model rather than a hard optimization, and it is the
+  # smallest reproducer of the all-failed path; see the note at the end of this
+  # test about the separate defect it also exposes.
+  bbp <- as.data.frame(BB_proportions)
+  bbp$center <- factor(rep_len(paste0("s", 1:6), nrow(bbp)))
+  bbp$period <- factor(rep_len(1:3, nrow(bbp)))
+  aliased <- suppressWarnings(glm(
+    EBP_proportions ~ center + period + coaching_updt + launch_duration,
+    data = bbp, family = quasibinomial(link = "logit")
+  ))
+  # the precondition, asserted rather than assumed: if a future R made this fit
+  # full rank the restarts would stop failing and this test would be vacuous
+  expect_true(anyNA(coef(aliased)))
+
+  run <- function() {
+    suppressWarnings(suppressMessages(lago_optimization(
+      data = bbp,
+      outcome_name = "EBP_proportions",
+      outcome_type = "continuous",
+      glm_family = "quasibinomial",
+      link = "logit",
+      intervention_components = c("coaching_updt", "launch_duration"),
+      intervention_lower_bounds = c(1, 1),
+      intervention_upper_bounds = c(40, 5),
+      cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+      outcome_goal = 0.85,
+      include_center_effects = TRUE,
+      include_time_effects = TRUE,
+      time_effect_optimization_value = 1,
+      include_confidence_set = FALSE,
+      quiet = TRUE
+    )))
+  }
+
+  # the message a user can act on, and the recommendation it makes
+  expect_error(run(), "Numerical optimization failed to find a solution")
+  expect_error(run(), "'grid_search'")
+  # and NOT the base-R error the missing guard produced. This is the assertion
+  # that fails without the fix: the old message was exactly this string.
+  expect_error(run(), "^(?!.*argument is of length zero).*$", perl = TRUE)
+
+  # NOT asserted here: that following the message's advice succeeds on THIS
+  # data. It does not, and deliberately so -- the cause on this fixture is the
+  # rank-deficient fit above, which grid_search cannot help with either. Asked
+  # for grid_search on the same inputs, the NA outcome reaches that optimizer's
+  # own goal comparison and it fails with the base-R "missing value where
+  # TRUE/FALSE needed", i.e. the same class of opaque failure this test fixes on
+  # the numerical path, in the other optimizer and from a different cause.
+  #
+  # That is a SEPARATE defect from the one under test and is left alone here: it
+  # is an unguarded NA outcome from an aliased model, not an unguarded
+  # all-failed restart set, and fixing it means refusing a rank-deficient fit,
+  # which is a wider behaviour change than this one. Pinned as the current
+  # behaviour so that the day it is fixed, this assertion is what says so.
+  grid_error <- tryCatch(
+    suppressWarnings(suppressMessages(lago_optimization(
+      data = bbp,
+      outcome_name = "EBP_proportions",
+      outcome_type = "continuous",
+      glm_family = "quasibinomial",
+      link = "logit",
+      intervention_components = c("coaching_updt", "launch_duration"),
+      intervention_lower_bounds = c(1, 1),
+      intervention_upper_bounds = c(40, 5),
+      cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+      outcome_goal = 0.85,
+      include_center_effects = TRUE,
+      include_time_effects = TRUE,
+      time_effect_optimization_value = 1,
+      optimization_method = "grid_search",
+      optimization_grid_search_step_size = c(4, 1),
+      include_confidence_set = FALSE,
+      quiet = TRUE
+    ))),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(grid_error, "missing value where TRUE/FALSE needed")
+
+  # and on a FULL-RANK fit of the same shape, where the aliasing is gone because
+  # 5 centers and 3 periods share no factor, both optimizers succeed. This is
+  # what confines the failures above to the rank-deficient fixture rather than
+  # to fixed center and time effects in general.
+  full_rank <- bbp
+  full_rank$center <- factor(rep_len(paste0("s", 1:5), nrow(full_rank)))
+  expect_false(anyNA(coef(suppressWarnings(glm(
+    EBP_proportions ~ center + period + coaching_updt + launch_duration,
+    data = full_rank, family = quasibinomial(link = "logit")
+  )))))
+  ok <- suppressWarnings(suppressMessages(lago_optimization(
+    data = full_rank,
+    outcome_name = "EBP_proportions",
+    outcome_type = "continuous",
+    glm_family = "quasibinomial",
+    link = "logit",
+    intervention_components = c("coaching_updt", "launch_duration"),
+    intervention_lower_bounds = c(1, 1),
+    intervention_upper_bounds = c(40, 5),
+    cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+    outcome_goal = 0.85,
+    include_center_effects = TRUE,
+    include_time_effects = TRUE,
+    time_effect_optimization_value = 1,
+    include_confidence_set = FALSE,
+    quiet = TRUE
+  )))
+  expect_length(ok$rec_int, 2)
+  expect_true(all(ok$rec_int >= c(1, 1)))
+  expect_true(all(ok$rec_int <= c(40, 5)))
+})

--- a/tests/testthat/test-optimization.R
+++ b/tests/testthat/test-optimization.R
@@ -358,4 +358,31 @@ test_that("an unsolvable numerical optimization says to use grid_search", {
   expect_length(ok$rec_int, 2)
   expect_true(all(ok$rec_int >= c(1, 1)))
   expect_true(all(ok$rec_int <= c(40, 5)))
+
+  # the comment above says BOTH optimizers succeed on the full-rank fit, so both
+  # are run: the call above takes the default numerical method, this one the grid
+  # search that fails on the aliased fixture. Asserting it is what confines that
+  # failure to rank deficiency rather than to the method.
+  ok_grid <- suppressWarnings(suppressMessages(lago_optimization(
+    data = full_rank,
+    outcome_name = "EBP_proportions",
+    outcome_type = "continuous",
+    glm_family = "quasibinomial",
+    link = "logit",
+    intervention_components = c("coaching_updt", "launch_duration"),
+    intervention_lower_bounds = c(1, 1),
+    intervention_upper_bounds = c(40, 5),
+    cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+    outcome_goal = 0.85,
+    optimization_method = "grid_search",
+    optimization_grid_search_step_size = c(10, 2),
+    include_center_effects = TRUE,
+    include_time_effects = TRUE,
+    time_effect_optimization_value = 1,
+    include_confidence_set = FALSE,
+    quiet = TRUE
+  )))
+  expect_length(ok_grid$rec_int, 2)
+  expect_true(all(ok_grid$rec_int >= c(1, 1)))
+  expect_true(all(ok_grid$rec_int <= c(40, 5)))
 })

--- a/tests/testthat/test-outcome-internals.R
+++ b/tests/testthat/test-outcome-internals.R
@@ -523,6 +523,7 @@ test_that("a FACTOR covariate's coefficient is excluded, not just its column", {
   fixed_effect_coef_names <- getFromNamespace(
     "fixed_effect_coef_names", "LAGO"
   )
+  claimed_coef_names <- getFromNamespace("claimed_coef_names", "LAGO")
 
   pulesa <- as.data.frame(main_pulesa_data)
   pulesa$center <- pulesa$Clinic
@@ -546,6 +547,42 @@ test_that("a FACTOR covariate's coefficient is excluded, not just its column", {
   no_mapping <- model
   attr(no_mapping$terms, "term.labels") <- character(0)
   expect_true(is.null(term_coef_names(no_mapping)))
+
+  # The levels come from model$xlevels rather than from the model frame, and the
+  # reason is a fit made with model = FALSE whose data has gone out of scope:
+  # that fit has no $model to read levels from. Reading them from there instead
+  # would pass every assertion below, because this fixture still carries its
+  # model frame, so the case that justifies the choice is asserted here on its
+  # own. Both conditions are needed to reach the fallback: model = FALSE alone
+  # leaves the term mapping intact.
+  detached <- local({
+    scoped <- pulesa
+    glm(
+      Proportions ~ center + AccessMedicines + AccessBPMachines + center_grp,
+      data = scoped, family = gaussian(), model = FALSE
+    )
+  })
+  expect_null(detached$model)
+  expect_false(is.null(detached$xlevels))
+  attr(detached$terms, "term.labels") <- character(0)
+  expect_true(is.null(term_coef_names(detached)))
+
+  # with no model frame to fall back on, the level-named coefficient is still
+  # held back and center still resolves to its 15 dummies. Reading levels from
+  # the absent frame gives 16, which is the recycling shape of the original
+  # defect.
+  detached_excluded <- claimed_coef_names(
+    detached, term_coef_names(detached),
+    c("(Intercept)", "AccessMedicines", "AccessBPMachines", "center_grp")
+  )
+  expect_true("center_grpb" %in% detached_excluded)
+  expect_length(
+    fixed_effect_coef_names(
+      "center", term_coef_names(detached), names(coef(detached)),
+      detached_excluded
+    ),
+    n_centers - 1
+  )
 
   # THROUGH THE CALLER, which is where the wrong number appeared. Taking the
   # fallback must give the same answer as resolving through the mapping: the

--- a/tests/testthat/test-outcome-internals.R
+++ b/tests/testthat/test-outcome-internals.R
@@ -972,6 +972,17 @@ test_that("the fallback equals the mapping for every column type it handles", {
     `unused level` = list(function(k) {
       factor(rep_len(c("a", "b"), k), levels = c("a", "b", "z"))
     }, NULL),
+    # levels in an order factor() would not choose for itself. Every other
+    # factor case here is alphabetical, so rebuilding the column WITHOUT
+    # carrying its levels over would still produce the right suffixes and this
+    # would all pass. Under contr.treatment the suffixes ARE the levels, so a
+    # rebuild that re-sorted them holds back a name the model does not have and
+    # misses one it does.
+    `unsorted levels` = list(function(k) {
+      factor(rep_len(c("mid", "lo", "hi"), k),
+        levels = c("mid", "lo", "hi")
+      )
+    }, NULL),
     `contr.sum` = list(
       function(k) factor(rep_len(c("a", "b", "c"), k)), "contr.sum"
     ),

--- a/tests/testthat/test-outcome-internals.R
+++ b/tests/testthat/test-outcome-internals.R
@@ -709,6 +709,393 @@ test_that("a FACTOR covariate's coefficient is excluded, not just its column", {
 })
 
 
+# the fixture the four tests below share: a 16-center pulesa fit with one
+# covariate column named center_cov, whose coefficient the anchored ^center
+# search will claim unless it is held back. The covariate's TYPE and CODING are
+# what vary. Returning the pieces rather than the model keeps each test's own
+# assertions about its coding local to it.
+contrast_fixture <- function(column, contrasts_arg = NULL) {
+  pulesa <- as.data.frame(main_pulesa_data)
+  pulesa$center <- pulesa$Clinic
+  pulesa$center_cov <- column(nrow(pulesa))
+  model <- if (is.null(contrasts_arg)) {
+    glm(Proportions ~ center + AccessMedicines + center_cov,
+      data = pulesa, family = gaussian()
+    )
+  } else {
+    glm(Proportions ~ center + AccessMedicines + center_cov,
+      data = pulesa, family = gaussian(),
+      contrasts = list(center_cov = contrasts_arg)
+    )
+  }
+  list(
+    data = pulesa,
+    model = model,
+    n_centers = length(levels(pulesa$Clinic)),
+    columns = c("(Intercept)", "AccessMedicines", "center_cov")
+  )
+}
+
+
+test_that("a LOGICAL covariate's coefficient is excluded (it has no xlevels)", {
+  # A logical column is contrast-coded exactly as a factor is -- glm() codes it
+  # as factor(x, c(FALSE, TRUE)) and its coefficient is center_covTRUE -- but it
+  # gets NO $xlevels entry at all. So an expansion driven off $xlevels saw fewer
+  # than two levels, held nothing back, and the anchored search claimed
+  # center_covTRUE as a 16th center dummy: #68's recycling shape on a column
+  # type the fix was meant to cover. The expansion is driven off $contrasts
+  # instead, which does list the column.
+  fx <- contrast_fixture(function(k) rep_len(c(TRUE, FALSE), k))
+  term_coef_names <- getFromNamespace("term_coef_names", "LAGO")
+  fixed_effect_coef_names <- getFromNamespace(
+    "fixed_effect_coef_names", "LAGO"
+  )
+  claimed_coef_names <- getFromNamespace("claimed_coef_names", "LAGO")
+
+  # the fixture's own preconditions: this is the asymmetry that is the defect
+  model_coef_names <- names(coef(fx$model))
+  expect_true("center_covTRUE" %in% model_coef_names)
+  expect_false("center_cov" %in% model_coef_names)
+  expect_true("center_cov" %in% names(fx$model$contrasts))
+  expect_false("center_cov" %in% names(fx$model$xlevels))
+
+  claimed <- claimed_coef_names(fx$model, NULL, fx$columns)
+  expect_true("center_covTRUE" %in% claimed)
+  # and the center block is its 15 real dummies, not 16
+  dummies <- fixed_effect_coef_names(
+    "center", NULL, model_coef_names, claimed
+  )
+  expect_length(dummies, fx$n_centers - 1)
+  expect_false("center_covTRUE" %in% dummies)
+  # the mapping path is the reference answer, and the fallback must equal it
+  mapping <- term_coef_names(fx$model)
+  expect_false(is.null(mapping))
+  expect_identical(
+    sort(dummies),
+    sort(fixed_effect_coef_names(
+      "center", mapping, model_coef_names,
+      claimed_coef_names(fx$model, mapping, fx$columns)
+    ))
+  )
+})
+
+
+test_that("an ORDERED covariate's coefficients are excluded (contr.poly)", {
+  # An ordered factor defaults to contr.poly, so its coefficients are
+  # center_cov.L and center_cov.Q -- polynomial contrasts, NOT one dummy per
+  # level. paste0(column, levels[-1]) built center_covmid and center_covhi,
+  # which are not coefficients of this model at all, so nothing real was held
+  # back and the anchored search claimed BOTH real ones as center dummies: 17
+  # against 16 weights. That is a larger silent error than the two-level factor
+  # case, because two extra effects enter rather than one.
+  fx <- contrast_fixture(function(k) {
+    factor(rep_len(c("lo", "mid", "hi"), k),
+      levels = c("lo", "mid", "hi"), ordered = TRUE
+    )
+  })
+  term_coef_names <- getFromNamespace("term_coef_names", "LAGO")
+  fixed_effect_coef_names <- getFromNamespace(
+    "fixed_effect_coef_names", "LAGO"
+  )
+  claimed_coef_names <- getFromNamespace("claimed_coef_names", "LAGO")
+
+  # the coefficients really are polynomial, and the level-named strings the old
+  # expansion built really are absent: without both halves there is no defect
+  model_coef_names <- names(coef(fx$model))
+  expect_true(all(c("center_cov.L", "center_cov.Q") %in% model_coef_names))
+  expect_false(any(c("center_covmid", "center_covhi") %in% model_coef_names))
+  expect_identical(fx$model$contrasts[["center_cov"]], "contr.poly")
+
+  claimed <- claimed_coef_names(fx$model, NULL, fx$columns)
+  expect_true(all(c("center_cov.L", "center_cov.Q") %in% claimed))
+  dummies <- fixed_effect_coef_names(
+    "center", NULL, model_coef_names, claimed
+  )
+  expect_length(dummies, fx$n_centers - 1)
+  expect_false(any(c("center_cov.L", "center_cov.Q") %in% dummies))
+  mapping <- term_coef_names(fx$model)
+  expect_false(is.null(mapping))
+  expect_identical(
+    sort(dummies),
+    sort(fixed_effect_coef_names(
+      "center", mapping, model_coef_names,
+      claimed_coef_names(fx$model, mapping, fx$columns)
+    ))
+  )
+})
+
+
+test_that("a NON-DEFAULT contrast's coefficients are excluded", {
+  # A caller may set any coding, through options(contrasts=) or the per-column
+  # contrasts= argument of glm(). contr.helmert names its dummies by POSITION,
+  # center_cov1 and center_cov2, so a levels-driven expansion built
+  # center_covb / center_covc -- names this model does not have -- and both real
+  # ones were claimed as center dummies. The suffixes come from the contrast
+  # matrix's colnames() instead, which is what glm() itself appends.
+  fx <- contrast_fixture(
+    function(k) factor(rep_len(c("a", "b", "c"), k)), "contr.helmert"
+  )
+  term_coef_names <- getFromNamespace("term_coef_names", "LAGO")
+  fixed_effect_coef_names <- getFromNamespace(
+    "fixed_effect_coef_names", "LAGO"
+  )
+  claimed_coef_names <- getFromNamespace("claimed_coef_names", "LAGO")
+
+  model_coef_names <- names(coef(fx$model))
+  expect_true(all(c("center_cov1", "center_cov2") %in% model_coef_names))
+  expect_false(any(c("center_covb", "center_covc") %in% model_coef_names))
+  # contr.helmert's own matrix has NO column names, so the suffixes are the
+  # column positions. Deriving them from colnames() alone would give nothing.
+  expect_null(colnames(contr.helmert(3)))
+
+  claimed <- claimed_coef_names(fx$model, NULL, fx$columns)
+  expect_true(all(c("center_cov1", "center_cov2") %in% claimed))
+  dummies <- fixed_effect_coef_names(
+    "center", NULL, model_coef_names, claimed
+  )
+  expect_length(dummies, fx$n_centers - 1)
+  mapping <- term_coef_names(fx$model)
+  expect_false(is.null(mapping))
+  expect_identical(
+    sort(dummies),
+    sort(fixed_effect_coef_names(
+      "center", mapping, model_coef_names,
+      claimed_coef_names(fx$model, mapping, fx$columns)
+    ))
+  )
+
+  # the same defect through options(contrasts=), which is set globally and so
+  # reaches a caller who never touched glm()'s contrasts argument. The coding is
+  # read off the FIT, so restoring the option must not change the answer.
+  previous <- options(contrasts = c("contr.sum", "contr.poly"))
+  summed <- contrast_fixture(function(k) factor(rep_len(c("a", "b", "c"), k)))
+  options(previous)
+  expect_identical(summed$model$contrasts[["center_cov"]], "contr.sum")
+  expect_identical(getOption("contrasts")[[1]], "contr.treatment")
+  summed_names <- names(coef(summed$model))
+  expect_true(all(c("center_cov1", "center_cov2") %in% summed_names))
+  expect_length(
+    fixed_effect_coef_names(
+      "center", NULL, summed_names,
+      claimed_coef_names(summed$model, NULL, summed$columns)
+    ),
+    summed$n_centers - 1
+  )
+})
+
+
+test_that("the fallback equals the mapping for every column type it handles", {
+  # The fallback is a reconstruction of what the term mapping gives, so the one
+  # requirement on it is that it AGREES with the mapping wherever the mapping
+  # exists. That is the strongest check available, because it does not depend on
+  # anybody's reasoning about what glm() names things: the mapping reads the
+  # names off the model matrix.
+  #
+  # Asserted per column type rather than on one model, because each type is
+  # coded differently and a fix for one need not fix another -- which is how a
+  # logical column and an ordered factor stayed broken while the two-level
+  # factor case was fixed.
+  term_coef_names <- getFromNamespace("term_coef_names", "LAGO")
+  fixed_effect_coef_names <- getFromNamespace(
+    "fixed_effect_coef_names", "LAGO"
+  )
+  claimed_coef_names <- getFromNamespace("claimed_coef_names", "LAGO")
+
+  unnamed_matrix <- contr.treatment(3)
+  colnames(unnamed_matrix) <- NULL
+  cases <- list(
+    numeric = list(function(k) seq_len(k) / k, NULL),
+    `factor 2 levels` = list(
+      function(k) factor(rep_len(c("a", "b"), k)), NULL
+    ),
+    `factor 4 levels` = list(
+      function(k) factor(rep_len(c("a", "b", "c", "d"), k)), NULL
+    ),
+    character = list(function(k) rep_len(c("a", "b"), k), NULL),
+    logical = list(function(k) rep_len(c(TRUE, FALSE), k), NULL),
+    ordered = list(function(k) {
+      factor(rep_len(c("lo", "mid", "hi"), k),
+        levels = c("lo", "mid", "hi"), ordered = TRUE
+      )
+    }, NULL),
+    `unused level` = list(function(k) {
+      factor(rep_len(c("a", "b"), k), levels = c("a", "b", "z"))
+    }, NULL),
+    `contr.sum` = list(
+      function(k) factor(rep_len(c("a", "b", "c"), k)), "contr.sum"
+    ),
+    `contr.SAS` = list(
+      function(k) factor(rep_len(c("a", "b", "c"), k)), "contr.SAS"
+    ),
+    `unnamed contrast matrix` = list(
+      function(k) factor(rep_len(c("a", "b", "c"), k)), unnamed_matrix
+    )
+  )
+
+  for (case in names(cases)) {
+    fx <- contrast_fixture(cases[[case]][[1]], cases[[case]][[2]])
+    mapping <- term_coef_names(fx$model)
+    # the mapping has to be available, or the comparison is vacuous
+    expect_false(is.null(mapping), info = case)
+    model_coef_names <- names(coef(fx$model))
+
+    # the invariant: the same center dummies either way
+    expect_identical(
+      sort(fixed_effect_coef_names(
+        "center", NULL, model_coef_names,
+        claimed_coef_names(fx$model, NULL, fx$columns)
+      )),
+      sort(fixed_effect_coef_names(
+        "center", mapping, model_coef_names,
+        claimed_coef_names(fx$model, mapping, fx$columns)
+      )),
+      info = case
+    )
+    # and it is the right SIZE, so the two agreeing is not two wrong answers
+    expect_length(
+      fixed_effect_coef_names(
+        "center", NULL, model_coef_names,
+        claimed_coef_names(fx$model, NULL, fx$columns)
+      ),
+      fx$n_centers - 1
+    )
+    # every name the fallback holds back for the covariate is a coefficient the
+    # model really has. The levels-driven expansion built center_covmid for an
+    # ordered factor, which is nobody's coefficient, and so held back nothing.
+    derived <- setdiff(
+      claimed_coef_names(fx$model, NULL, fx$columns), fx$columns
+    )
+    expect_true(all(derived %in% model_coef_names), info = case)
+    # and the covariate's own coefficients are exactly what the mapping says
+    expect_identical(
+      sort(unique(c(derived, "center_cov"))),
+      sort(unique(c(mapping[["center_cov"]], "center_cov"))),
+      info = case
+    )
+  }
+})
+
+
+test_that("the fallback equals the mapping on a fit with no model frame", {
+  # The route the fallback is written for: a model = FALSE fit whose data= name
+  # has left scope. That fit has no $model to read a level or a coding from, so
+  # the derivation must come off $contrasts and $xlevels, which both survive it.
+  # model = FALSE alone is not enough -- model.matrix() re-derives the frame
+  # from the data, which is still reachable -- so the term labels are cleared
+  # too, which is what makes term_coef_names() return NULL.
+  term_coef_names <- getFromNamespace("term_coef_names", "LAGO")
+  fixed_effect_coef_names <- getFromNamespace(
+    "fixed_effect_coef_names", "LAGO"
+  )
+  claimed_coef_names <- getFromNamespace("claimed_coef_names", "LAGO")
+
+  pulesa <- as.data.frame(main_pulesa_data)
+  pulesa$center <- pulesa$Clinic
+  n_centers <- length(levels(pulesa$Clinic))
+  # a logical and an ordered column together, i.e. the two types with no
+  # $xlevels entry and no per-level naming
+  pulesa$center_flag <- rep_len(c(TRUE, FALSE), nrow(pulesa))
+  pulesa$center_ord <- factor(
+    rep_len(c("lo", "mid", "hi"), nrow(pulesa)),
+    levels = c("lo", "mid", "hi"), ordered = TRUE
+  )
+  formula <- Proportions ~ center + AccessMedicines + center_flag + center_ord
+  columns <- c(
+    "(Intercept)", "AccessMedicines", "center_flag", "center_ord"
+  )
+
+  model <- glm(formula, data = pulesa, family = gaussian())
+  mapping <- term_coef_names(model)
+  expect_false(is.null(mapping))
+  reference <- sort(fixed_effect_coef_names(
+    "center", mapping, names(coef(model)),
+    claimed_coef_names(model, mapping, columns)
+  ))
+  expect_length(reference, n_centers - 1)
+
+  # model = FALSE ALONE leaves the mapping intact: the frame is gone, but the
+  # name given as data= is still reachable from the formula's environment, so
+  # model.matrix() re-derives one. This is the half the comment used to omit.
+  still_reachable <- local({
+    scoped <- pulesa
+    glm(Proportions ~ center + AccessMedicines + center_flag + center_ord,
+      data = scoped, family = gaussian(), model = FALSE
+    )
+  })
+  expect_null(still_reachable$model)
+  expect_false(is.null(term_coef_names(still_reachable)))
+
+  # with the name out of scope as well, there is neither a frame to read nor
+  # data to rebuild one from, and the mapping really is NULL. No term label is
+  # cleared here: this is the route as a caller reaches it.
+  detached <- local({
+    scoped <- pulesa
+    glm(formula, data = scoped, family = gaussian(), model = FALSE)
+  })
+  expect_null(detached$model)
+  expect_true(is.null(term_coef_names(detached)))
+  # and what the derivation needs did survive. $contrasts lists the logical
+  # column even though $xlevels does not, which is why it is the source used.
+  expect_false(is.null(detached$contrasts))
+  expect_true("center_flag" %in% names(detached$contrasts))
+  expect_false("center_flag" %in% names(detached$xlevels))
+  expect_true("center_ord" %in% names(detached$xlevels))
+
+  claimed <- claimed_coef_names(detached, NULL, columns)
+  expect_true("center_flagTRUE" %in% claimed)
+  expect_true(all(c("center_ord.L", "center_ord.Q") %in% claimed))
+  expect_identical(
+    sort(fixed_effect_coef_names(
+      "center", NULL, names(coef(detached)), claimed
+    )),
+    reference
+  )
+
+  # THROUGH THE CALLER, which is where the wrong number appeared: two extra
+  # effects entered all_center_lvl_effects, the weights recycled against it, and
+  # the reported outcome was off by 10.5% with nothing said. Held back, the
+  # fallback reports what the mapping does.
+  rec_int_processor <- getFromNamespace("rec_int_processor", "LAGO")
+  run <- function(fitted) {
+    suppressWarnings(suppressMessages(rec_int_processor(
+      data = pulesa,
+      model = fitted,
+      center_characteristics = NULL,
+      additional_covariates = c("center_flag", "center_ord"),
+      include_center_effects = TRUE,
+      include_time_effects = FALSE,
+      include_interaction_terms = FALSE,
+      main_components = NULL,
+      intervention_components = "AccessMedicines",
+      optimization_method = "grid_search",
+      optimization_grid_search_step_size = 5,
+      link = "identity",
+      center_weights_for_outcome_goal = rep(1 / n_centers, n_centers),
+      cost_list_of_vectors = list(c(0, 1)),
+      intervention_lower_bounds = 0,
+      intervention_upper_bounds = 10,
+      outcome_goal = 0.6,
+      center_characteristics_optimization_values = NULL,
+      time_effect_optimization_value = NULL,
+      lower_outcome_goal = FALSE,
+      prev_recommended_interventions = NULL,
+      shrinkage_threshold = 0.25,
+      power_goal = NULL,
+      power_goal_approach = "unconditional",
+      num_centers_in_next_stage = NULL,
+      patients_per_center_in_next_stage = NULL,
+      outcome_name = "Proportions"
+    )))
+  }
+  via_mapping <- run(model)
+  via_fallback <- run(detached)
+  expect_identical(
+    via_fallback$est_outcome_goal, via_mapping$est_outcome_goal
+  )
+  expect_identical(via_fallback$rec_int, via_mapping$rec_int)
+})
+
+
 test_that("lago_optimization() passes additional_covariates on to the processor", {
   # The test above runs rec_int_processor() directly, so it pins what the callee
   # does with the argument but not that its caller supplies it. Deleting the one

--- a/tests/testthat/test-outcome-internals.R
+++ b/tests/testthat/test-outcome-internals.R
@@ -502,6 +502,176 @@ test_that("rec_int_processor() itself excludes the covariates it names", {
   )
 })
 
+
+test_that("a FACTOR covariate's coefficient is excluded, not just its column", {
+  # The test above uses a NUMERIC covariate, center_size, whose single
+  # coefficient IS named after its column, so passing the column name held it
+  # back. A factor or character covariate is one coefficient per non-reference
+  # level, each named after the LEVEL: a column center_grp with levels a/b is a
+  # coefficient named center_grpb. So a list of column names held back nothing
+  # for it, the anchored search claimed center_grpb as a 16th center dummy, and
+  # the numeric case passing was not evidence the factor case did.
+  #
+  # This is #68's defect surviving on the factor case alone, and it is a wrong
+  # NUMBER rather than an error: all_center_lvl_effects came back 17 long
+  # against 16 weights, the weights recycled, and the reported outcome was off
+  # by 5% with nothing said. The exclusion list is therefore built from the
+  # coefficient names the predictors account for, which claimed_coef_names()
+  # resolves from the model.
+  rec_int_processor <- getFromNamespace("rec_int_processor", "LAGO")
+  term_coef_names <- getFromNamespace("term_coef_names", "LAGO")
+  fixed_effect_coef_names <- getFromNamespace(
+    "fixed_effect_coef_names", "LAGO"
+  )
+
+  pulesa <- as.data.frame(main_pulesa_data)
+  pulesa$center <- pulesa$Clinic
+  # a FACTOR covariate whose own name begins with "center", i.e. the #68 shape
+  # one level down
+  pulesa$center_grp <- factor(rep_len(c("a", "b"), nrow(pulesa)))
+  model <- glm(
+    Proportions ~ center + AccessMedicines + AccessBPMachines + center_grp,
+    data = pulesa, family = gaussian()
+  )
+  n_centers <- length(levels(pulesa$Clinic))
+  expect_equal(n_centers, 16)
+
+  # the fixture has to contain the confusable name, or there is nothing to be
+  # wrongly claimed. The coefficient is named after the LEVEL, not the column:
+  # that asymmetry is the whole defect.
+  model_coef_names <- names(coef(model))
+  expect_true("center_grpb" %in% model_coef_names)
+  expect_false("center_grp" %in% model_coef_names)
+
+  no_mapping <- model
+  attr(no_mapping$terms, "term.labels") <- character(0)
+  expect_true(is.null(term_coef_names(no_mapping)))
+
+  # THROUGH THE CALLER, which is where the wrong number appeared. Taking the
+  # fallback must give the same answer as resolving through the mapping: the
+  # fallback is a reconstruction of the mapping's result, so the two agreeing is
+  # the whole requirement on it.
+  run <- function(fitted) {
+    suppressWarnings(suppressMessages(rec_int_processor(
+      data = pulesa,
+      model = fitted,
+      center_characteristics = NULL,
+      additional_covariates = "center_grp",
+      include_center_effects = TRUE,
+      include_time_effects = FALSE,
+      include_interaction_terms = FALSE,
+      main_components = NULL,
+      intervention_components = c("AccessMedicines", "AccessBPMachines"),
+      optimization_method = "grid_search",
+      optimization_grid_search_step_size = c(5, 0.5),
+      link = "identity",
+      center_weights_for_outcome_goal = rep(1 / n_centers, n_centers),
+      cost_list_of_vectors = list(c(0, 1), c(0, 1)),
+      intervention_lower_bounds = c(0, 0),
+      intervention_upper_bounds = c(10, 1),
+      outcome_goal = 0.6,
+      center_characteristics_optimization_values = NULL,
+      time_effect_optimization_value = NULL,
+      lower_outcome_goal = FALSE,
+      prev_recommended_interventions = NULL,
+      shrinkage_threshold = 0.25,
+      power_goal = NULL,
+      power_goal_approach = "unconditional",
+      num_centers_in_next_stage = NULL,
+      patients_per_center_in_next_stage = NULL,
+      outcome_name = "Proportions"
+    )))
+  }
+  via_mapping <- run(model)
+  via_fallback <- run(no_mapping)
+  expect_identical(
+    via_fallback$est_outcome_goal, via_mapping$est_outcome_goal
+  )
+  expect_identical(via_fallback$rec_int, via_mapping$rec_int)
+  expect_identical(via_fallback$rec_int_cost, via_mapping$rec_int_cost)
+
+  # and the value itself, so this is not two wrong numbers agreeing. The
+  # unfixed fallback reported 0.745 against this 0.708, a 5.2% error, which is
+  # the magnitude the recycling produces here.
+  expect_equal(via_mapping$est_outcome_goal, 0.708333856066007,
+    tolerance = 1e-12
+  )
+
+  # and the same thing one layer down, in the names themselves. This is placed
+  # AFTER the end-to-end assertions on purpose: the defect is a wrong NUMBER, so
+  # what must fail on an unfixed tree is the comparison above, not a lookup of a
+  # helper that tree does not have.
+  # the list the caller owes now names the coefficient, and the model's own
+  # xlevels is where the level comes from, so no name is guessed from its shape
+  columns <- c(
+    "(Intercept)", "AccessMedicines", "AccessBPMachines", "center_grp"
+  )
+  claimed <- getFromNamespace("claimed_coef_names", "LAGO")(
+    no_mapping, NULL, columns
+  )
+  expect_true("center_grpb" %in% claimed)
+  # the column name is kept too: a numeric column IS its own coefficient name
+  expect_true(all(columns %in% claimed))
+
+  # with it, only the 15 real dummies are claimed
+  expect_length(
+    fixed_effect_coef_names("center", NULL, model_coef_names, claimed),
+    n_centers - 1
+  )
+  expect_false("center_grpb" %in%
+    fixed_effect_coef_names("center", NULL, model_coef_names, claimed))
+  # and with the raw COLUMN names, which is what used to be passed, the factor
+  # coefficient is claimed as a 16th. This is the assertion that fails if the
+  # list regresses to column names.
+  expect_true("center_grpb" %in%
+    fixed_effect_coef_names("center", NULL, model_coef_names, columns))
+  expect_length(
+    fixed_effect_coef_names("center", NULL, model_coef_names, columns),
+    n_centers
+  )
+
+
+  # the OTHER call site, get_confidence_set(), on the same fallback model. It
+  # cross-checks its assembled columns against the model's coefficients, so the
+  # extra claimed dummy there is refused rather than reported as a number: its
+  # symptom was an error, not a wrong answer. The fix does not make this model
+  # work -- a factor covariate held at its reference level is still one column
+  # against two coefficient names -- but it does make the refusal name the one
+  # coefficient that is genuinely unmatched instead of all 16.
+  cs_error <- tryCatch(
+    suppressWarnings(suppressMessages(get_confidence_set(
+      predictors_data = pulesa[, c(
+        "center", "AccessMedicines", "AccessBPMachines", "center_grp"
+      ), drop = FALSE],
+      include_center_effects = TRUE,
+      center_weights_for_outcome_goal = rep(1 / n_centers, n_centers),
+      additional_covariates = "center_grp",
+      intervention_components = c("AccessMedicines", "AccessBPMachines"),
+      outcome_data = pulesa$Proportions,
+      fitted_model = no_mapping,
+      link = "identity",
+      outcome_goal = 0.6,
+      outcome_type = "continuous",
+      intervention_lower_bounds = c(0, 0),
+      intervention_upper_bounds = c(10, 1),
+      confidence_set_grid_step_size = c(5, 0.5),
+      cost_list_of_vectors = list(c(0, 1), c(0, 1)),
+      rec_int = c(5, 0.5)
+    ))),
+    error = function(e) conditionMessage(e)
+  )
+  expect_match(cs_error, "do not match the predictors")
+  # the unmatched coefficient is the factor dummy and NOTHING else: the 15 real
+  # center dummies are resolved. Unfixed, all 15 were listed here too, because
+  # the block was one column too wide and every name shifted.
+  unmatched <- sub(
+    ".*coefficient\\(s\\) with no matching predictor: ([^\n]*).*", "\\1",
+    cs_error
+  )
+  expect_identical(trimws(unmatched), "center_grpb")
+})
+
+
 test_that("lago_optimization() passes additional_covariates on to the processor", {
   # The test above runs rec_int_processor() directly, so it pins what the callee
   # does with the argument but not that its caller supplies it. Deleting the one
@@ -742,6 +912,64 @@ test_that("a restart whose optimization failed is not selected", {
   # substitution is not smuggling in different arithmetic
   expect_identical(srb_cost(c(3, 1)), srb_cost_as_assembled(c(3, 1)))
   expect_identical(srb_cost(c(4, 1)), srb_cost_as_assembled(c(4, 1)))
+})
+
+
+test_that("an all-failed restart set is refused by one guard, for both loops", {
+  # The refusal the test above relies on being upstream. Both restart loops of
+  # the numerical optimizer record a failed solnl() as NA and carry on, and both
+  # have to refuse the case where every restart failed, because there is then
+  # nothing to select. The cost loop always did; the max-achievable-outcome loop
+  # did not, and reached which.max() over an all-NA vector, which is integer(0),
+  # so the outcome it indexed was numeric(0) and the goal comparison two
+  # statements later failed with the base-R error "argument is of length zero"
+  # rather than telling the caller what to do instead.
+  #
+  # The condition and the wording are now one function both loops call, so this
+  # tests the guard itself rather than one loop's copy of it.
+  refuse_if_all_restarts_failed <- getFromNamespace(
+    "refuse_if_all_restarts_failed", "LAGO"
+  )
+
+  # all failed: refused, and by the message that names the way out
+  expect_error(
+    refuse_if_all_restarts_failed(rep(NA_real_, 11)),
+    "Numerical optimization failed to find a solution"
+  )
+  expect_error(
+    refuse_if_all_restarts_failed(rep(NA_real_, 11)),
+    "'grid_search'"
+  )
+  # a single restart, failed, is still every restart
+  expect_error(
+    refuse_if_all_restarts_failed(NA_real_),
+    "Numerical optimization failed to find a solution"
+  )
+
+  # SOME failing is not this case and must pass through untouched, which is the
+  # half that a guard written as any(is.na()) would break: one bad starting
+  # point out of eleven has to leave the optimization running.
+  expect_silent(refuse_if_all_restarts_failed(c(NA_real_, 0.5, NA_real_)))
+  expect_null(refuse_if_all_restarts_failed(c(NA_real_, 0.5)))
+  expect_silent(refuse_if_all_restarts_failed(c(0.1, 0.2, 0.3)))
+
+  # and what the surviving restarts then resolve to, which is the reason the
+  # partial case is safe to pass through: which.max() skips NAs, so it returns
+  # the position of the best SURVIVOR in the original indexing. Both the value
+  # and the restart's converged point are indexed by that same position, so they
+  # stay the pair one restart produced rather than being read off different
+  # restarts.
+  results <- c(NA_real_, 0.4, NA_real_, 0.9, 0.2)
+  points <- matrix(
+    c(0, 0, 4, 1, 0, 0, 9, 2, 1, 3),
+    nrow = 2
+  )
+  max_position <- which.max(results)
+  expect_identical(max_position, 4L)
+  expect_identical(results[max_position], 0.9)
+  expect_identical(points[, max_position], c(9, 2))
+  # not the NA-bearing first column, which an is.na()-blind max would take
+  expect_false(identical(points[, 1], points[, max_position]))
 })
 
 

--- a/tests/testthat/test-outcome-internals.R
+++ b/tests/testthat/test-outcome-internals.R
@@ -382,6 +382,57 @@ test_that("both callers pass the names they have already claimed", {
 })
 
 
+test_that("a covariate named exactly like a fixed effect keeps the term's dummies", {
+  # The exclusion list is built by appending each column's levels to its own
+  # name, which is a string, and for a covariate named exactly "center" those
+  # strings ARE the names of the real center dummies. Holding them back takes
+  # every genuine dummy out of the center effects and leaves them empty, which
+  # is worse than the over-claiming the list prevents, and once the term mapping
+  # is gone nothing distinguishes the two. Such a column is therefore left out
+  # of the list.
+  #
+  # Every other fixture in this file names its covariate with a PREFIX of the
+  # term (center_size, center_grp, center_flag), which the list must still hold
+  # back. Only an exact match is dropped, so both assertions are made here: an
+  # earlier attempt at this fix filtered on startsWith() and reintroduced the
+  # defect the prefixed fixtures cover.
+  claimed_coef_names <- getFromNamespace("claimed_coef_names", "LAGO")
+
+  pulesa <- as.data.frame(main_pulesa_data)
+  pulesa$center <- pulesa$Clinic
+  model <- glm(
+    Proportions ~ center + AccessMedicines,
+    data = pulesa, family = gaussian()
+  )
+  real_dummies <- grep("^center", names(coef(model)), value = TRUE)
+  expect_length(real_dummies, length(levels(pulesa$Clinic)) - 1)
+
+  # a covariate named exactly "center": none of the real dummies may be held
+  # back, or the center effects come back empty
+  exact <- claimed_coef_names(model, NULL, c(
+    "(Intercept)", "AccessMedicines", "center"
+  ))
+  expect_equal(sum(real_dummies %in% exact), 0)
+
+  # a covariate named with the term as a PREFIX is still held back, which is the
+  # case the exclusion list exists for
+  pulesa$center_grp <- factor(rep_len(c("a", "b"), nrow(pulesa)))
+  prefixed_model <- glm(
+    Proportions ~ center + AccessMedicines + center_grp,
+    data = pulesa, family = gaussian()
+  )
+  prefixed <- claimed_coef_names(prefixed_model, NULL, c(
+    "(Intercept)", "AccessMedicines", "center_grp"
+  ))
+  expect_true("center_grpb" %in% prefixed)
+  expect_equal(
+    sum(grep("^center", names(coef(prefixed_model)), value = TRUE) %in%
+      prefixed),
+    1
+  )
+})
+
+
 test_that("rec_int_processor() itself excludes the covariates it names", {
   # The test above builds the exclusion list the way the callers build it, which
   # pins what the list must BE but cannot observe a caller that stops passing

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -316,6 +316,14 @@ test_that("center_weights_for_outcome_goal must be non-negative and finite", {
   # admits floating-point noise and not a weight the caller meant
   expect_error(cw(c(0.5, 0.51, -0.01)), "must be non-negative")
 
+  # and the boundary itself, so the gate cannot be widened without a test
+  # failing. Asserting only the two cases above leaves every size in between
+  # unconstrained: a gate of -1e-3 would satisfy them both while admitting
+  # weights that are negative by far more than any subtraction explains.
+  # Anything past a few units in the last place of 1 is refused.
+  expect_error(cw(c(0.5, 0.5, -1e-9)), "must be non-negative")
+  expect_error(cw(c(0.5, 0.5, -1e-12)), "must be non-negative")
+
   # a weight of exactly 0 is ALLOWED, deliberately: it means a center the
   # recommendation is not being computed for, which is what the package itself
   # builds from center_effects_optimization_values (the named center gets 1 and

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -291,6 +291,31 @@ test_that("center_weights_for_outcome_goal must be non-negative and finite", {
   # and a mild one, also summing to 1
   expect_error(cw(c(-0.05, 0.55, 0.5)), "must be non-negative")
 
+  # a residual weight, written the way a caller writes it, is ALLOWED even
+  # though it lands a few floating-point units below zero. R evaluates
+  # 1 - .3 - .3 - .4 left to right and the result is -5.55e-17, while
+  # 1 - sum(c(.3, .3, .4)) folds the addends first and gives exactly 0, so only
+  # the sequential form reaches this at all. The vector still sums to exactly 1.
+  # Refusing it would contradict allowing a weight of exactly 0 two assertions
+  # below, which is why the check compares against a tolerance.
+  # The fixture above has three centers. Which literals produce a negative
+  # residual depends on how R folds them, so the value is stated outright
+  # rather than computed here: one unit in the last place below zero, which is
+  # what a caller's subtraction can land on.
+  residual <- -.Machine$double.eps / 2
+  expect_lt(residual, 0)
+  # accepted rather than returned unchanged: the vector sums to a hair under 1,
+  # so the renormalisation rescales it, which is its job. What this asserts is
+  # that the sign check does not refuse it.
+  expect_equal(
+    cw(c(0.5, 0.5, residual))$center_weights_for_outcome_goal,
+    c(0.5, 0.5, residual),
+    tolerance = 1e-12
+  )
+  # a weight negative by more than rounding is still refused, so the tolerance
+  # admits floating-point noise and not a weight the caller meant
+  expect_error(cw(c(0.5, 0.51, -0.01)), "must be non-negative")
+
   # a weight of exactly 0 is ALLOWED, deliberately: it means a center the
   # recommendation is not being computed for, which is what the package itself
   # builds from center_effects_optimization_values (the named center gets 1 and

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -266,6 +266,104 @@ test_that("center_weights_for_outcome_goal must sum to 1", {
     "sum up to 1")
 })
 
+test_that("center_weights_for_outcome_goal must be non-negative and finite", {
+  # Summing to 1 does not make a vector a set of weights. The weights are a
+  # convex combination over the centers -- the reported outcome is
+  # sum(weight_i * outcome_i), a weighted MEAN of the per-center outcomes -- so
+  # a negative weight lets the result leave the range of the values it averages.
+  # c(-10, 11, 0) sums to exactly 1, passed every check, and produced a logit
+  # "probability" of 10.95 for a binary outcome: a wrong number, silently.
+  cw <- function(w) {
+    a <- vi_args(include_center_effects = TRUE,
+      center_weights_for_outcome_goal = w)
+    a$data <- data.frame(
+      mpg = c(21, 22, 23, 24, 25, 26),
+      gear = c(3, 4, 3, 4, 3, 4),
+      qsec = c(16, 17, 18, 19, 20, 21),
+      center = factor(c(1, 1, 2, 2, 3, 3))
+    )
+    suppressMessages(do.call(LAGO:::validate_inputs, a))
+  }
+
+  # the wild case, summing to EXACTLY 1 so the sum check cannot catch it
+  expect_identical(sum(c(-10, 11, 0)), 1)
+  expect_error(cw(c(-10, 11, 0)), "must be non-negative")
+  # and a mild one, also summing to 1
+  expect_error(cw(c(-0.05, 0.55, 0.5)), "must be non-negative")
+
+  # a weight of exactly 0 is ALLOWED, deliberately: it means a center the
+  # recommendation is not being computed for, which is what the package itself
+  # builds from center_effects_optimization_values (the named center gets 1 and
+  # every other center 0). Refusing 0 would refuse that documented path.
+  expect_identical(
+    cw(c(0.5, 0.5, 0))$center_weights_for_outcome_goal,
+    c(0.5, 0.5, 0)
+  )
+  expect_identical(
+    cw(c(1, 0, 0))$center_weights_for_outcome_goal,
+    c(1, 0, 0)
+  )
+
+  # NA, NaN and Inf are named rather than reaching the sum comparison, where
+  # any(NA < 0) is not FALSE but the base-R error "missing value where
+  # TRUE/FALSE needed" -- which said nothing about weights.
+  for (bad in list(c(NA_real_, 0.5, 0.5), c(NaN, 0.5, 0.5),
+    c(Inf, 0.5, 0.5), c(Inf, -Inf, 1))) {
+    expect_error(cw(bad), "must all be finite")
+  }
+  expect_error(cw(c(NA_real_, 0.5, 0.5)), "not weights")
+
+  # all-zero weights are refused by the sum check, which is also what keeps the
+  # renormalisation from dividing by zero: a vector summing to 0 is 1 away from
+  # 1, not within the 0.001 tolerance of it.
+  expect_error(cw(c(0, 0, 0)), "sum up to 1")
+
+  # a compliant vector is still returned untouched, so none of the above
+  # narrowed what is accepted
+  expect_identical(
+    cw(c(0.25, 0.25, 0.5))$center_weights_for_outcome_goal,
+    c(0.25, 0.25, 0.5)
+  )
+})
+
+test_that("the weight checks cover the DEFAULT weights, not just supplied", {
+  # The checks are placed after every branch that can produce the weights, not
+  # inside the one that reads them from the caller, so they cover the
+  # center-size default and the single-named-center indicator as well. That
+  # matters: the default is center_sizes / total_sample_size, which with every
+  # center_sample_size zero is 0/0, i.e. all NaN, and it then reached the sum
+  # comparison as the opaque "missing value where TRUE/FALSE needed".
+  a <- vi_args(include_center_effects = TRUE, outcome_type = "binary",
+    glm_family = "binomial", input_data_structure = "center_level",
+    outcome_name = "proportion", intervention_components = c("x1", "x2"),
+    intervention_lower_bounds = c(0, 0), intervention_upper_bounds = c(10, 10),
+    outcome_goal = 0.6)
+  a$data <- data.frame(
+    proportion = c(0.4, 0.5, 0.6, 0.7),
+    center_sample_size = c(0, 0, 0, 0),
+    center = factor(c("a", "b", "c", "d")),
+    x1 = c(1, 2, 3, 4), x2 = c(2, 3, 4, 5)
+  )
+  expect_error(suppressMessages(do.call(LAGO:::validate_inputs, a)),
+    "must all be finite")
+  # and the message says where an unsupplied set of weights came from, since the
+  # caller passed none and would otherwise have nothing to go on
+  expect_error(suppressMessages(do.call(LAGO:::validate_inputs, a)),
+    "center_sample_size")
+
+  # with real sample sizes the same call is accepted and the default weights are
+  # the sample-size shares, so the guard did not break the path it guards.
+  # Compared as values: on the center_level path the default comes from tapply()
+  # and so carries that function's 1-d array shape, which is pre-existing and
+  # not what this test is about.
+  a$data$center_sample_size <- c(10, 20, 30, 40)
+  expect_identical(
+    as.numeric(suppressMessages(do.call(LAGO:::validate_inputs,
+      a))$center_weights_for_outcome_goal),
+    c(0.1, 0.2, 0.3, 0.4)
+  )
+})
+
 
 # --- Group 3: time effects, interaction terms, additional covariates --------
 


### PR DESCRIPTION
### An all-failed numerical optimization crashed obscurely

  With every `solnl()` restart failed, `which.max()` over an all-`NA` vector
  returned nothing and the achievability comparison died with `argument is of
  length zero`. The package's own "consider grid_search" message sat 60 lines
  downstream, never reached. The check now happens where the restarts are counted.

  ### A factor covariate's coefficient was claimed as a centre dummy

  The names each block holds back from the fixed-effect name search were column
  names, but a contrast-coded column's coefficients are named after the *contrast*,
  not the column: `center_grp` never held back `center_grpb`, which was then taken
  as an extra centre dummy. The centre effects gained an entry, the weights
  recycled, and the outcome was ~5% wrong, silently.

  My first fix appended levels to the column name. Review showed that is only
  correct for one coding on a column with recorded levels — a `logical` column
  (`flagTRUE`, no `$xlevels` entry) and an `ordered` factor (`.L`/`.Q`) were still
  not held back at all, the latter a *larger* error than the case I'd fixed.
  `contr.SAS` and `C(f, base = 2)` were worse still: they produced plausible but
  wrong names, holding back one real coefficient and one phantom. The names now
  come from the coding the model recorded, and where the term mapping is available
  the two agree by construction — asserted per column type, which is the check that
  doesn't depend on anyone's reasoning about how a name is spelled.

  ### Negative centre weights were accepted

  Type, length and sum were checked; sign was not. A negative weight produced a
  reported probability of `10.95`. Now refused, after every branch that produces
  weights, including the defaults — a data set whose centre sample sizes are all
  zero yields all-`NaN`. Zero weights stay allowed: the package builds them itself.

  ### Found while reviewing the above

  Appending a level to a column name is a string, and for a covariate named exactly
  `center` those strings *are* the real centre dummies' names — so all 15 genuine
  dummies were held back and the centre effects came back empty (~26% wrong). Such
  a column is left out of the list, so the search over-claims and the caller's
  coefficient count refuses the model, reporting the collision rather than
  resolving it wrongly in either direction.