### PR TITLE
Feature/python wrapper

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^DESIGN_.*\.md$
 ^ISSUE_.*\.md$
 ^tests/js$
+^python$

--- a/NEWS.md
+++ b/NEWS.md
@@ -233,6 +233,26 @@
   covariate and its observed range, since the reported outcome and interval are
   then an extrapolation to a covariate value that never occurs in the data. The
   covariate is still held at 0, so no returned value changes. (#75)
+* The robust and clustered variance estimator for a logit outcome model is now
+  computed by a compiled Rcpp kernel instead of two per-observation R loops.
+  Only the accumulation of the bread and meat matrices moves to C++, so the
+  matrix inversion stays in R and the returned variance is numerically
+  identical to before, while the clustered confidence set is far faster on
+  larger data. This is the package's first compiled code, so `Rcpp` is now a
+  dependency. (#79)
+* `visualize_cost()` now draws its total-cost and marginal-cost curves
+  client-side with D3 instead of as server-rendered images, so they redraw
+  instantly as the sliders move. Each curve gains a hover read-out, the right
+  endpoint of the total-cost curve is draggable to rescale all of a component's
+  coefficients at once (the sliders follow the drag), and the curves are tinted
+  red when the coefficients are invalid. D3 is bundled with its license, so the
+  app works offline. (#80)
+* Added a Python wrapper (in `python/`, importable as `lago`) that lets Python
+  users call LAGO through `rpy2`. It wraps `lago_optimization()`,
+  `get_confidence_set()`, `visualize_cost()` and `lago_report()`, converting a
+  pandas data frame and Python lists to and from R, and calls the real R
+  functions rather than reimplementing anything, so the results are exactly R's.
+  It embeds R, so R and the installed LAGO package are required.
 * Added runnable `@examples` to every exported function that lacked them:
   `get_confidence_set()` and the `print()`, `summary()`, and `plot()` methods
   for `"lago"` objects. Every exported function now ships an example.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ The LAGO R package bridges the gap between theoretical advances in Learn-As-you-
 3. [Basic use case](#basic-use-case)
 4. [More advanced use case](#more-advanced-use-case)
 5. [How to run additional examples](#how-to-run-additional-examples)
-6. [Relevant LAGO papers](#relevant-lago-papers)
-7. [How to get help](#how-to-get-help)
+6. [Using LAGO from Python](#using-lago-from-python)
+7. [Relevant LAGO papers](#relevant-lago-papers)
+8. [How to get help](#how-to-get-help)
 
 
 ## How to install the R package
@@ -369,6 +370,40 @@ Confidence set and the optimization algorithm:
 Outcome model and testing:
 - [test_fit_diagnostics](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_fit_diagnostics.Rmd) — fit diagnostics that warn about a questionable outcome model (glm warnings, near-singular estimates, non-significant components) while the optimization continues.
 - [test_overall_intervention](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/tests/manual_tests/test_overall_intervention.Rmd) — overall intervention-effect test, reported when a `group` column is supplied.
+
+## Using LAGO from Python
+
+A Python wrapper lives in [`python/`](https://github.com/correspondMerchant/LAGO-R-Package/tree/main/python) (importable as `lago`) for people who work in Python. It calls the real R functions through [`rpy2`](https://rpy2.github.io/), so the results are exactly the ones the R package produces. Because it embeds R, you need R and the installed LAGO R package as well as the Python package.
+
+```python
+import pandas as pd
+import lago
+
+res = lago.optimize(
+    data=df,                                  # a pandas DataFrame
+    outcome_name="Y",
+    outcome_type="binary",
+    intervention_components=["comp1", "comp2"],
+    intervention_lower_bounds=[0, 0],
+    intervention_upper_bounds=[10, 10],
+    cost_list=[[0, 1.7], [0, 8]],
+    outcome_goal=0.85,
+)
+res["rec_int"]           # recommended intervention, a Python list
+res["est_outcome_goal"]  # estimated outcome, a float
+
+# visualize_cost() launches the same interactive R app in your browser and
+# returns the cost list to Python when you close it:
+cost_list = lago.visualize_cost(
+    component_names=["comp1", "comp2"],
+    unit_costs=[0.5, 1],
+    default_cost_fxn_type="cubic",
+    intervention_lower_bounds=[0, 0],
+    intervention_upper_bounds=[10, 10],
+)
+```
+
+See [`python/README.md`](https://github.com/correspondMerchant/LAGO-R-Package/blob/main/python/README.md) for installation and the full API.
 
 ## Relevant LAGO papers
 1. [Nevo D, Lok JJ, Spiegelman D. ANALYSIS OF "LEARN-AS-YOU-GO" (LAGO) STUDIES. Ann Stat. 2021 Apr;49(2):793-819. doi: 10.1214/20-aos1978. Epub 2021 Apr 2. PMID: 35510045; PMCID: PMC9067111.](https://pmc.ncbi.nlm.nih.gov/articles/PMC9067111/pdf/nihms-1761299.pdf)

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.egg-info/
+build/
+dist/
+.pytest_cache/

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,152 @@
+# lago-python
+
+A Python wrapper for the [LAGO](https://github.com/correspondMerchant/LAGO-R-Package) R package.
+
+## Honest note (read this first)
+
+**This wrapper EMBEDS R via [rpy2](https://rpy2.github.io/). R and the installed
+`LAGO` R package are REQUIRED at runtime.** It does not reimplement any LAGO
+math. Every function calls the corresponding exported R function in `LAGO` and
+converts inputs/outputs between Python-native types and R objects.
+
+In other words: this gives Python users LAGO's API in Python syntax. It is
+**not** an R-free install of LAGO. You must have:
+
+- a working R installation (rpy2 must be able to reach it, i.e. `R_HOME` set),
+- the `LAGO` R package installed in that R,
+- `rpy2` and `pandas` installed for Python.
+
+`visualize_cost()` **opens a browser and BLOCKS** until you close the app (it
+launches the R Shiny + D3 cost-function visualizer, unchanged, R-side).
+
+## Install
+
+```bash
+pip install rpy2 pandas
+pip install -e python/   # from the repo root, or `pip install .` inside python/
+```
+
+Point rpy2 at your R (example for a conda R):
+
+```bash
+export R_HOME="$(R RHOME)"
+```
+
+## Usage
+
+```python
+import pandas as pd
+import lago
+
+# `data` is a pandas DataFrame; it is converted to an R data.frame.
+result = lago.optimize(
+    data=df,
+    outcome_name="case",
+    outcome_type="binary",
+    glm_family="binomial",
+    intervention_components=["age", "parity"],
+    intervention_lower_bounds=[0, 0],
+    intervention_upper_bounds=[50, 10],
+    cost_list=[[0, 4], [0, 1]],     # list-of-lists -> R list of numeric vectors
+    outcome_goal=0.5,
+    outcome_goal_intention="maximize",
+    confidence_set_grid_step_size=[1, 1],
+    quiet=True,
+)
+
+result["rec_int"]           # list[float], the recommended intervention
+result["est_outcome_goal"]  # float
+result["rec_int_cost"]      # float
+result["cs"]                # pandas.DataFrame (the confidence set) or None
+result["est_outcome_ci"]    # {"lower": .., "upper": ..} or None
+result["model"]             # raw rpy2 glm object (does NOT convert cleanly)
+```
+
+Any argument of the R `lago_optimization()` can be passed through as a keyword
+argument (e.g. `center_characteristics`, `power_goal`, `link`, `unit_costs`,
+`include_confidence_set`).
+
+### Confidence set
+
+```python
+cs = lago.get_confidence_set(
+    predictors_data=df[["coaching_updt", "launch_duration", "birth_volume_100"]],
+    intervention_components=["coaching_updt", "launch_duration"],
+    outcome_data=list(df["pp3_oxytocin_mother"]),
+    fitted_model=result["model"],      # the raw rpy2 glm object from optimize()
+    link="logit",
+    outcome_goal=0.85,
+    outcome_type="binary",
+    intervention_lower_bounds=[1, 1],
+    intervention_upper_bounds=[40, 5],
+    confidence_set_grid_step_size=[1, 1],
+    cost_list=[[0, 1.7], [0, 8]],
+    rec_int=result["rec_int"],
+)
+cs["confidence_set_size_percentage"]  # float
+cs["rec_int_ci"]                      # {"lower": .., "upper": ..} or None
+cs["cs"]                              # pandas.DataFrame or None
+```
+
+### HTML report
+
+```python
+path = lago.lago_report(result, output_file="report.html", title="My report")
+# -> path to the rendered HTML file (str)
+```
+
+`lago_report()` accepts the dict returned by `optimize()` (it reuses the
+underlying R object stored under `_r_object`), so the optimization is not
+re-run.
+
+### Cost-function visualizer (interactive, blocking)
+
+```python
+cost_list = lago.visualize_cost(
+    component_names=["Component 1", "Component 2"],
+    unit_costs=[0.5, 1.0],
+    default_cost_fxn_type="linear",
+    intervention_lower_bounds=[0, 0],
+    intervention_upper_bounds=[10, 10],
+)
+# Opens a browser and BLOCKS. Close the app with its
+# "Return list to R & close" button to get the cost list back as a
+# python list-of-lists (suitable to pass as cost_list= to optimize()).
+# Closing the browser tab instead returns nothing.
+```
+
+## What does not convert cleanly
+
+- The fitted outcome `model` (an R `glm` object) is returned as the raw rpy2
+  object under `result["model"]`, not a Python-native structure. You can pass
+  it straight into `get_confidence_set(fitted_model=...)`.
+- The whole R result is also kept under `result["_r_object"]` so it can be fed
+  to `lago_report()` without re-running the optimization.
+
+## Testing
+
+```bash
+cd python && pytest
+```
+
+The tests embed R and require the `LAGO` R package to be installed; if R/rpy2/
+LAGO cannot be reached the suite skips itself. `visualize_cost()` is **not**
+auto-tested because it launches a blocking browser app; only its R-call
+construction is checked. Test it interactively by hand.
+
+### Environment note (conda R)
+
+rpy2 loads R's shared library at import. With a conda R you must point rpy2 at
+it and, on older host systems, put the conda libs first so R's newer C++
+runtime (`libstdc++`, `libicu`) is found before the system one:
+
+```bash
+export R_HOME="$(R RHOME)"
+export R_LIBS="$R_HOME/library"
+export LD_LIBRARY_PATH="$(dirname "$R_HOME")/lib:$LD_LIBRARY_PATH"
+```
+
+Under `pytest` this `LD_LIBRARY_PATH` ordering matters: pytest's plugins load
+C extensions before rpy2, which can otherwise pin an older system `libstdc++`
+and fail with `GLIBCXX_... not found` when R's library is dlopen'd.
+```

--- a/python/lago/__init__.py
+++ b/python/lago/__init__.py
@@ -1,0 +1,277 @@
+"""lago-python: a Python wrapper around the LAGO R package.
+
+This package EMBEDS R via rpy2. It does not reimplement any LAGO math; every
+function here calls the corresponding exported R function in the installed
+``LAGO`` R package and converts inputs/outputs between Python-native types and
+R objects.
+
+Requirements at runtime: a working R installation, the ``LAGO`` R package
+installed in R, plus rpy2 and pandas on the Python side. This is NOT an R-free
+install; it gives Python users LAGO's API in Python syntax.
+
+Exposed functions (mirroring the 4 exported R functions):
+    optimize()           -> lago_optimization()
+    get_confidence_set() -> get_confidence_set()
+    visualize_cost()     -> visualize_cost()   (opens a browser, BLOCKS)
+    lago_report()        -> lago_report()
+"""
+
+from __future__ import annotations
+
+from . import _bridge
+
+__all__ = [
+    "optimize",
+    "get_confidence_set",
+    "visualize_cost",
+    "lago_report",
+]
+
+__version__ = "0.1.0"
+
+
+def optimize(
+    data,
+    outcome_name,
+    outcome_type,
+    intervention_components,
+    intervention_lower_bounds,
+    intervention_upper_bounds,
+    outcome_goal=None,
+    cost_list=None,
+    quiet=True,
+    **kwargs,
+):
+    """Run a LAGO optimization by calling R's ``lago_optimization()``.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        The input dataset. Converted to an R ``data.frame``.
+    outcome_name : str
+        Name of the outcome column.
+    outcome_type : str
+        ``"binary"`` or ``"continuous"``.
+    intervention_components : list[str]
+        Names of the intervention component columns.
+    intervention_lower_bounds, intervention_upper_bounds : list[float]
+        Per-component bounds.
+    outcome_goal : float, optional
+        The desired outcome level. At least one of ``outcome_goal`` or
+        ``power_goal`` (via kwargs) must be given.
+    cost_list : list[list[float]], optional
+        The cost-function coefficients per component, as a Python list of
+        lists. Maps to R's ``cost_list_of_vectors`` (a list of numeric
+        vectors). Either this or ``unit_costs`` must be supplied.
+    quiet : bool, default True
+        Suppress R's paced console output. Defaults to True for programmatic
+        use; the returned value is identical either way.
+    **kwargs
+        Any other argument of ``lago_optimization()`` is passed through
+        verbatim (e.g. ``glm_family``, ``link``, ``center_characteristics``,
+        ``center_characteristics_optimization_values``,
+        ``confidence_set_grid_step_size``, ``power_goal``, ``unit_costs``,
+        ``outcome_goal_intention``, ``include_confidence_set``, ...).
+
+    Returns
+    -------
+    dict
+        Result fields converted to Python-native types:
+        ``rec_int`` (list of floats), ``est_outcome_goal`` (float),
+        ``rec_int_cost`` (float), ``est_outcome_ci`` (dict lower/upper when
+        present), ``confidence_set_size_percentage`` (float when present),
+        ``cs`` (pandas.DataFrame when a non-empty confidence set exists, else
+        None), plus echoed metadata. The fitted ``model`` is returned as the
+        raw rpy2 glm object (it does not convert cleanly). The underlying R
+        result object is kept under ``"_r_object"`` for use with
+        :func:`lago_report`.
+    """
+    call_kwargs = dict(
+        data=data,
+        outcome_name=outcome_name,
+        outcome_type=outcome_type,
+        intervention_components=intervention_components,
+        intervention_lower_bounds=intervention_lower_bounds,
+        intervention_upper_bounds=intervention_upper_bounds,
+        quiet=quiet,
+    )
+    if outcome_goal is not None:
+        call_kwargs["outcome_goal"] = outcome_goal
+    if cost_list is not None:
+        call_kwargs["cost_list_of_vectors"] = cost_list
+    call_kwargs.update(kwargs)
+
+    result = _bridge.call_lago("lago_optimization", call_kwargs)
+    return _bridge.lago_result_to_dict(result)
+
+
+def get_confidence_set(
+    predictors_data,
+    intervention_components,
+    outcome_data,
+    fitted_model,
+    link,
+    outcome_goal,
+    outcome_type,
+    intervention_lower_bounds,
+    intervention_upper_bounds,
+    confidence_set_grid_step_size,
+    cost_list=None,
+    rec_int=None,
+    **kwargs,
+):
+    """Compute a confidence set by calling R's ``get_confidence_set()``.
+
+    Parameters
+    ----------
+    predictors_data : pandas.DataFrame
+        The predictor columns the model was fitted on. Converted to an R
+        ``data.frame``.
+    intervention_components : list[str]
+    outcome_data : list[float]
+        The outcome vector.
+    fitted_model : rpy2 object
+        A fitted glm model, e.g. ``optimize(...)["model"]``.
+    link : str
+        ``"logit"`` or ``"identity"``.
+    outcome_goal : float
+    outcome_type : str
+        ``"binary"`` or ``"continuous"``.
+    intervention_lower_bounds, intervention_upper_bounds : list[float]
+    confidence_set_grid_step_size : list[float]
+    cost_list : list[list[float]]
+        Cost coefficients per component (maps to ``cost_list_of_vectors``).
+    rec_int : list[float]
+        The recommended intervention, e.g. ``optimize(...)["rec_int"]``.
+    **kwargs
+        Other ``get_confidence_set()`` arguments (e.g.
+        ``center_characteristics``,
+        ``center_characteristics_optimization_values``,
+        ``confidence_set_alpha``).
+
+    Returns
+    -------
+    dict
+        ``confidence_set_size_percentage`` (float),
+        ``rec_int_ci`` (dict lower/upper, or None),
+        ``cs`` (pandas.DataFrame, or None when empty).
+    """
+    call_kwargs = dict(
+        predictors_data=predictors_data,
+        intervention_components=intervention_components,
+        outcome_data=outcome_data,
+        fitted_model=fitted_model,
+        link=link,
+        outcome_goal=outcome_goal,
+        outcome_type=outcome_type,
+        intervention_lower_bounds=intervention_lower_bounds,
+        intervention_upper_bounds=intervention_upper_bounds,
+        confidence_set_grid_step_size=confidence_set_grid_step_size,
+    )
+    if cost_list is not None:
+        call_kwargs["cost_list_of_vectors"] = cost_list
+    if rec_int is not None:
+        call_kwargs["rec_int"] = rec_int
+    call_kwargs.update(kwargs)
+
+    result = _bridge.call_lago("get_confidence_set", call_kwargs)
+    out = _bridge.r_to_py(result)
+    # r_to_py no longer scalar-collapses length-1 vectors, so unwrap the
+    # genuinely-scalar fields (confidence_set_size_percentage) by name here.
+    # rec_int_ci (named c(lower, upper)) stays a dict; cs stays a DataFrame.
+    if isinstance(out, dict):
+        out = _bridge.scalarize_dict(out)
+    return out
+
+
+def visualize_cost(
+    component_names,
+    unit_costs,
+    default_cost_fxn_type,
+    intervention_lower_bounds,
+    intervention_upper_bounds,
+):
+    """Launch the R Shiny + D3 cost-function visualizer (R-side, unchanged).
+
+    .. warning::
+        This OPENS A BROWSER and BLOCKS until you close the app. The R Shiny
+        app must be closed with its "Return list to R & close" button for the
+        cost list to be returned; closing the browser tab returns nothing.
+
+    Python's only role is to trigger the R app and receive the cost list it
+    returns. When the app is closed via the button, R returns the current
+    cost-function coefficient list; this function converts it to a Python
+    list-of-lists (one list of floats per component) and returns it.
+
+    Parameters
+    ----------
+    component_names : list[str]
+    unit_costs : list[float]
+    default_cost_fxn_type : str
+        ``"linear"`` or ``"cubic"``.
+    intervention_lower_bounds, intervention_upper_bounds : list[float]
+
+    Returns
+    -------
+    list[list[float]]
+        The cost-function coefficient list as it stood when the app closed,
+        suitable to pass back as ``cost_list`` to :func:`optimize`. May be
+        None if the app was closed without returning a list.
+    """
+    call_kwargs = dict(
+        component_names=component_names,
+        unit_costs=unit_costs,
+        default_cost_fxn_type=default_cost_fxn_type,
+        intervention_lower_bounds=intervention_lower_bounds,
+        intervention_upper_bounds=intervention_upper_bounds,
+    )
+    result = _bridge.call_lago("visualize_cost", call_kwargs)
+    return _bridge.r_to_py(result)
+
+
+def lago_report(result, output_file=None, title=None, open=False, **kwargs):
+    """Render an HTML report by calling R's ``lago_report()``.
+
+    Parameters
+    ----------
+    result : dict | rpy2 object
+        A result from :func:`optimize` (its ``"_r_object"`` is used), or a raw
+        rpy2 "lago" object.
+    output_file : str, optional
+        Path to write the HTML report to. If None, R uses a temp file.
+    title : str, optional
+        Report title.
+    open : bool, default False
+        Whether R should open the report in a browser.
+    **kwargs
+        Passed through to ``rmarkdown::render()`` via ``lago_report()``.
+
+    Returns
+    -------
+    str
+        The path to the rendered HTML file.
+    """
+    if isinstance(result, dict):
+        x = result.get("_r_object")
+        if x is None:
+            raise ValueError(
+                "result dict has no '_r_object'; pass the dict returned by "
+                "lago.optimize(...) or a raw rpy2 'lago' object."
+            )
+    else:
+        x = result  # assume raw rpy2 "lago" object
+
+    call_kwargs = {"x": x, "open": open}
+    if output_file is not None:
+        call_kwargs["output_file"] = output_file
+    if title is not None:
+        call_kwargs["title"] = title
+    call_kwargs.update(kwargs)
+
+    rendered = _bridge.call_lago("lago_report", call_kwargs)
+    path = _bridge.r_to_py(rendered)
+    # lago_report returns a length-1 character vector. r_to_py now yields a
+    # list (it no longer scalar-collapses), so unwrap to the bare path string.
+    if isinstance(path, list) and len(path) == 1:
+        path = path[0]
+    return path

--- a/python/lago/_bridge.py
+++ b/python/lago/_bridge.py
@@ -1,0 +1,294 @@
+"""Internal rpy2 bridge for the LAGO Python wrapper.
+
+This module embeds R through rpy2 and calls the real ``LAGO`` R functions. It
+performs NO LAGO math of its own; it only converts Python-native inputs to R
+objects, invokes the exported R functions, and converts their results back to
+Python-native types.
+
+R and the installed ``LAGO`` R package are required at runtime. rpy2 must be
+able to reach R (``R_HOME`` set to the R installation). See the package README.
+"""
+
+from __future__ import annotations
+
+# Lazy, memoized rpy2 / R initialization so that ``import lago`` does not touch
+# R until a wrapper function is actually called.
+_state: dict = {}
+
+
+# Result fields that are GENUINELY single-valued and should be presented to the
+# caller as a bare Python scalar (float/int/bool/str), not a length-1 list. Any
+# result field NOT listed here keeps whatever container r_to_py produced: a
+# semantic vector (rec_int, intervention_lower_bounds/upper_bounds, grid step
+# sizes, intervention_components, cost_list_of_vectors, ...) stays a Python list
+# (or list-of-lists) even when it holds a single value, and a named R vector
+# (est_outcome_ci, rec_int_ci) stays a dict. This is the allowlist half of the
+# "vectors stay lists, only real scalars collapse" design.
+SCALAR_RESULT_FIELDS = frozenset({
+    # lago_optimization() / get_confidence_set() numeric scalars
+    "rec_int_cost",
+    "est_outcome_goal",
+    "confidence_set_size_percentage",
+    # echoed scalar metadata / inputs recap
+    "outcome_type",
+    "outcome_goal",
+    "power_goal",
+    "effective_outcome_goal",
+    "outcome_name",
+    "family",
+    "link",
+    "input_nrow",
+    "input_ncol",
+    "include_center_effects",
+    "include_time_effects",
+    "include_interaction_terms",
+})
+
+
+def scalarize(name: str, value):
+    """Collapse a length-1 list to its element for genuinely-scalar fields.
+
+    Applied per result field by name: only fields in
+    :data:`SCALAR_RESULT_FIELDS` are unwrapped, and only when the converted
+    value is a length-1 list. Everything else (multi-element lists, dicts,
+    DataFrames, None, raw rpy2 objects) is returned unchanged, so semantic
+    vector fields keep their list container even at length 1.
+    """
+    if name in SCALAR_RESULT_FIELDS and isinstance(value, list) and len(value) == 1:
+        return value[0]
+    return value
+
+
+def scalarize_dict(d: dict) -> dict:
+    """Apply :func:`scalarize` to every entry of a result dict, by key."""
+    return {k: scalarize(k, v) for k, v in d.items()}
+
+
+def _ensure() -> dict:
+    """Initialize rpy2, import the LAGO R package, and cache the handles."""
+    if _state:
+        return _state
+
+    import rpy2.robjects as ro
+    import rpy2.rinterface as ri
+    from rpy2.robjects.packages import importr
+    from rpy2.robjects import pandas2ri
+    from rpy2.robjects.conversion import localconverter
+
+    lago = importr("LAGO")
+
+    _state.update(
+        ro=ro,
+        ri=ri,
+        lago=lago,
+        pandas2ri=pandas2ri,
+        localconverter=localconverter,
+        rfuncs={},
+    )
+    return _state
+
+
+def _pandas_converter():
+    """Combined default + pandas<->R converter."""
+    s = _ensure()
+    return s["ro"].default_converter + s["pandas2ri"].converter
+
+
+def _is_null(obj) -> bool:
+    """True for the R NULL singleton."""
+    s = _ensure()
+    ri = s["ri"]
+    if obj is ri.NULL:
+        return True
+    null_type = getattr(ri, "NULLType", None)
+    if null_type is not None and isinstance(obj, null_type):
+        return True
+    # Fallback: robjects wraps NULL too.
+    return str(type(obj)).endswith("NULLType'>")
+
+
+def py_to_r(value):
+    """Convert a single Python value to the corresponding R object.
+
+    - pandas.DataFrame -> R data.frame
+    - bool / list-of-bool -> logical vector
+    - int|float / list-of-number -> numeric vector
+    - str / list-of-str -> character vector
+    - list-of-lists (e.g. cost_list_of_vectors) -> R list of numeric vectors
+    - None -> R NULL
+    - an existing rpy2 object -> passed through unchanged
+    """
+    s = _ensure()
+    ro = s["ro"]
+    import pandas as pd
+    from rpy2.robjects.vectors import (
+        FloatVector,
+        StrVector,
+        BoolVector,
+    )
+
+    if value is None:
+        return ro.NULL
+
+    if isinstance(value, pd.DataFrame):
+        with s["localconverter"](_pandas_converter()):
+            return ro.conversion.get_conversion().py2rpy(value)
+
+    # bool must be checked before int (bool is a subclass of int)
+    if isinstance(value, bool):
+        return BoolVector([value])
+    if isinstance(value, (int, float)):
+        return FloatVector([float(value)])
+    if isinstance(value, str):
+        return StrVector([value])
+
+    if isinstance(value, (list, tuple)):
+        seq = list(value)
+        if len(seq) > 0 and all(isinstance(el, (list, tuple)) for el in seq):
+            # list-of-lists -> unnamed R list of numeric vectors
+            rlist = ro.r["list"]
+            return rlist(
+                *[FloatVector([float(x) for x in el]) for el in seq]
+            )
+        if len(seq) > 0 and all(isinstance(el, bool) for el in seq):
+            return BoolVector(seq)
+        if all(isinstance(el, (int, float)) and not isinstance(el, bool)
+               for el in seq):
+            return FloatVector([float(x) for x in seq])
+        if all(isinstance(el, str) for el in seq):
+            return StrVector(seq)
+        raise TypeError(
+            "Cannot convert list with mixed/unsupported element types to an "
+            "R vector: {!r}".format(seq)
+        )
+
+    # Already an rpy2 object (escape hatch) -> pass through unchanged.
+    return value
+
+
+def r_to_py(obj):
+    """Convert an R object to a Python-native value.
+
+    NULL -> None, data.frame -> pandas.DataFrame, named vector -> dict,
+    UNNAMED vector -> Python list (ALWAYS, even length 1), R list ->
+    dict/list (each element converted recursively, so a list of numeric
+    vectors round-trips as a list of lists with its nesting intact).
+    Anything that does not convert cleanly (e.g. a fitted glm model) is
+    returned as the raw rpy2 object.
+
+    This function deliberately does NOT collapse a length-1 vector to a bare
+    scalar: doing so would corrupt the CONTAINER TYPE of semantic vectors
+    (``rec_int``, ``intervention_lower_bounds``/``upper_bounds``, grid step
+    sizes, a degree-0 cost component, ...) whenever they happen to hold a
+    single value. Unwrapping to a scalar is instead applied field-by-field
+    in the result marshaling (see :data:`SCALAR_RESULT_FIELDS` and
+    :func:`scalarize`) only for fields that are genuinely single-valued.
+    """
+    s = _ensure()
+    ro = s["ro"]
+    ri = s["ri"]
+    from rpy2.robjects.vectors import (
+        FloatVector,
+        IntVector,
+        BoolVector,
+        StrVector,
+        ListVector,
+        DataFrame,
+        FactorVector,
+    )
+
+    if _is_null(obj):
+        return None
+
+    if isinstance(obj, DataFrame):
+        with s["localconverter"](_pandas_converter()):
+            return ro.conversion.get_conversion().rpy2py(obj)
+
+    if isinstance(obj, FactorVector):
+        levels = list(obj.levels)
+        out = []
+        for code in list(obj):
+            # R factor codes are 1-based; NA shows up as a large negative /
+            # NA integer.
+            try:
+                idx = int(code)
+            except (TypeError, ValueError):
+                out.append(None)
+                continue
+            out.append(levels[idx - 1] if 1 <= idx <= len(levels) else None)
+        return out
+
+    if isinstance(obj, ListVector):
+        names = obj.names
+        if _is_null(names):
+            # Each element is converted on its own, so a length-1 numeric
+            # vector element stays a length-1 list -> the list-of-vectors
+            # nesting (e.g. cost_list_of_vectors) is preserved, never
+            # flattened.
+            return [r_to_py(el) for el in obj]
+        return {str(n): r_to_py(obj.rx2(n)) for n in list(names)}
+
+    if isinstance(obj, (FloatVector, IntVector, BoolVector, StrVector)):
+        vals = list(obj)
+        names = obj.names
+        if not _is_null(names):
+            return {str(k): v for k, v in zip(list(names), vals)}
+        # A plain (unnamed) vector ALWAYS becomes a Python list, even length
+        # 1. Scalar unwrapping is a result-field concern, not a conversion
+        # concern (see scalarize / SCALAR_RESULT_FIELDS).
+        return vals
+
+    # Fallback: hand back the raw rpy2 object (e.g. a fitted glm model).
+    return obj
+
+
+def _get_rfunc(name: str):
+    """Fetch (and cache) an exported LAGO R function object.
+
+    Uses a plain robjects Function via ``LAGO::name`` so that keyword argument
+    names are passed to R verbatim (no underscore/dot signature translation).
+    """
+    s = _ensure()
+    cache = s["rfuncs"]
+    if name not in cache:
+        cache[name] = s["ro"].r("LAGO::" + name)
+    return cache[name]
+
+
+def build_r_kwargs(kwargs: dict) -> dict:
+    """Convert a dict of Python kwargs to a dict of R objects (no R call)."""
+    return {k: py_to_r(v) for k, v in kwargs.items()}
+
+
+def call_lago(name: str, kwargs: dict):
+    """Convert kwargs, call the exported LAGO R function, return the R result."""
+    rfunc = _get_rfunc(name)
+    r_kwargs = build_r_kwargs(kwargs)
+    return rfunc(**r_kwargs)
+
+
+def lago_result_to_dict(result) -> dict:
+    """Convert a "lago" result object into a Python dict.
+
+    The fitted ``model`` (an R glm object) does not convert cleanly, so it is
+    kept as the raw rpy2 object under ``"model"``. The whole underlying R
+    object is stored under ``"_r_object"`` so it can be handed to
+    ``lago.lago_report()`` without re-running the optimization.
+    """
+    out = {}
+    names = result.names
+    if _is_null(names):
+        # Unnamed (unexpected) - convert positionally.
+        return {"_r_object": result, "_values": r_to_py(result)}
+    for n in list(names):
+        val = result.rx2(n)
+        if n == "model":
+            out["model"] = val  # raw rpy2 glm object
+        else:
+            # r_to_py never scalar-collapses; unwrap here ONLY for the fields
+            # that are genuinely single-valued, so semantic vectors (rec_int,
+            # bounds, cost_list_of_vectors, ...) keep their list container even
+            # when length 1.
+            out[n] = scalarize(str(n), r_to_py(val))
+    out["_r_object"] = result
+    return out

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lago-python"
+version = "0.1.0"
+description = "Python wrapper for the LAGO R package (calls the real R functions via rpy2)."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "GPL-3.0-only" }
+authors = [
+    { name = "Ante Bing", email = "abing@bu.edu" },
+]
+keywords = ["LAGO", "optimization", "rpy2", "R", "intervention"]
+classifiers = [
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+]
+dependencies = [
+    "rpy2>=3.5",
+    "pandas>=1.3",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://github.com/correspondMerchant/LAGO-R-Package"
+Issues = "https://github.com/correspondMerchant/LAGO-R-Package/issues"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["lago*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,52 @@
+"""Shared pytest fixtures for the lago-python wrapper tests.
+
+These tests EMBED R via rpy2 and require the LAGO R package to be installed.
+If R / rpy2 / LAGO cannot be reached, the whole test module is skipped with a
+clear reason rather than erroring.
+"""
+import warnings
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def ro():
+    ro = pytest.importorskip("rpy2.robjects")
+    try:
+        from rpy2.robjects.packages import importr
+        importr("LAGO")
+    except Exception as exc:  # pragma: no cover - environment guard
+        pytest.skip(f"LAGO R package not importable via rpy2: {exc}")
+    return ro
+
+
+@pytest.fixture(scope="session")
+def bb_data(ro):
+    """R's built-in LAGO BB_data as a pandas DataFrame."""
+    from rpy2.robjects.packages import importr, data
+    from rpy2.robjects import pandas2ri
+    from rpy2.robjects.conversion import localconverter
+
+    lagor = importr("LAGO")
+    bb_r = data(lagor).fetch("BB_data")["BB_data"]
+    with localconverter(ro.default_converter + pandas2ri.converter):
+        return ro.conversion.get_conversion().rpy2py(bb_r)
+
+
+@pytest.fixture(scope="session")
+def infert(ro):
+    """R's built-in infert dataset as a pandas DataFrame."""
+    from rpy2.robjects import pandas2ri
+    from rpy2.robjects.conversion import localconverter
+
+    infert_r = ro.r("infert")
+    with localconverter(ro.default_converter + pandas2ri.converter):
+        return ro.conversion.get_conversion().rpy2py(infert_r)
+
+
+@pytest.fixture(autouse=True)
+def _silence_r_warnings():
+    """LAGO emits expected data/model-fit warnings; keep test output clean."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        yield

--- a/python/tests/test_wrapper.py
+++ b/python/tests/test_wrapper.py
@@ -1,0 +1,374 @@
+"""End-to-end tests for the lago-python wrapper.
+
+Every test drives the REAL LAGO R functions through rpy2. There is no mocked
+LAGO math: the wrapper's job is only to convert inputs/outputs, so the tests
+prove the round trip and that the wrapper does not corrupt the call.
+
+visualize_cost() is intentionally NOT launched here: it opens a blocking Shiny
+browser app. Instead we test that the wrapper builds the correct R call. See
+test_visualize_cost_builds_r_call and the README note.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+
+import lago
+from lago import _bridge
+
+
+# ---- shared optimization kwargs (BB_data, non-empty confidence set) --------
+
+def _bb_kwargs():
+    return dict(
+        outcome_name="pp3_oxytocin_mother",
+        outcome_type="binary",
+        glm_family="binomial",
+        intervention_components=["coaching_updt", "launch_duration"],
+        center_characteristics=["birth_volume_100"],
+        center_characteristics_optimization_values=1.75,
+        intervention_lower_bounds=[1, 1],
+        intervention_upper_bounds=[40, 5],
+        cost_list=[[0, 1.7], [0, 8]],
+        outcome_goal=0.85,
+        outcome_goal_intention="maximize",
+        confidence_set_grid_step_size=[1, 1],
+        quiet=True,
+    )
+
+
+# --------------------------------------------------------------------------
+# 1. Core round-trip proof
+# --------------------------------------------------------------------------
+def test_optimize_end_to_end(infert):
+    res = lago.optimize(
+        data=infert,
+        outcome_name="case",
+        outcome_type="binary",
+        glm_family="binomial",
+        intervention_components=["age", "parity"],
+        intervention_lower_bounds=[0, 0],
+        intervention_upper_bounds=[50, 10],
+        cost_list=[[0, 4], [0, 1]],
+        outcome_goal=0.5,
+        outcome_goal_intention="maximize",
+        confidence_set_grid_step_size=[1, 1],
+        quiet=True,
+    )
+    assert isinstance(res, dict)
+    rec = res["rec_int"]
+    assert isinstance(rec, list)
+    assert len(rec) == 2
+    assert all(isinstance(v, float) for v in rec)
+    assert isinstance(res["est_outcome_goal"], float)
+    assert isinstance(res["rec_int_cost"], float)
+
+
+# --------------------------------------------------------------------------
+# 2. Wrapper does not corrupt the call: matches direct R
+# --------------------------------------------------------------------------
+def test_result_matches_R(ro, infert):
+    res = lago.optimize(
+        data=infert,
+        outcome_name="case",
+        outcome_type="binary",
+        glm_family="binomial",
+        intervention_components=["age", "parity"],
+        intervention_lower_bounds=[0, 0],
+        intervention_upper_bounds=[50, 10],
+        cost_list=[[0, 4], [0, 1]],
+        outcome_goal=0.5,
+        outcome_goal_intention="maximize",
+        confidence_set_grid_step_size=[1, 1],
+        quiet=True,
+    )
+    ro.r(
+        """
+        res_r <- LAGO::lago_optimization(
+          data = infert,
+          outcome_name = "case",
+          outcome_type = "binary",
+          glm_family = "binomial",
+          intervention_components = c("age", "parity"),
+          intervention_lower_bounds = c(0, 0),
+          intervention_upper_bounds = c(50, 10),
+          cost_list_of_vectors = list(c(0, 4), c(0, 1)),
+          outcome_goal = 0.5,
+          outcome_goal_intention = "maximize",
+          confidence_set_grid_step_size = c(1, 1),
+          quiet = TRUE
+        )
+        """
+    )
+    rec_int_r = list(ro.r("res_r$rec_int"))
+    est_r = list(ro.r("res_r$est_outcome_goal"))[0]
+
+    assert np.allclose(
+        np.array(res["rec_int"], dtype=float),
+        np.array(rec_int_r, dtype=float),
+    )
+    assert np.isclose(res["est_outcome_goal"], est_r)
+
+
+# --------------------------------------------------------------------------
+# 3. cost_list (python list-of-lists) reaches R correctly
+# --------------------------------------------------------------------------
+def test_cost_list_roundtrip(bb_data):
+    cost_list = [[0, 1.7], [0, 8]]
+    res = lago.optimize(data=bb_data, cost_list=cost_list, **{
+        k: v for k, v in _bb_kwargs().items() if k != "cost_list"
+    })
+    # The run succeeded with the supplied cost_list, and LAGO echoes it back on
+    # the result as cost_list_of_vectors (converted to a python list-of-lists).
+    echoed = res["cost_list_of_vectors"]
+    assert isinstance(echoed, list)
+    assert len(echoed) == 2
+    assert np.allclose(echoed[0], [0.0, 1.7])
+    assert np.allclose(echoed[1], [0.0, 8.0])
+
+
+def test_cost_list_converts_to_r_list_of_numeric(ro):
+    """The Python list-of-lists becomes an R list of numeric vectors."""
+    r_obj = _bridge.py_to_r([[0, 1.7], [0, 8]])
+    assert list(ro.r["class"](r_obj))[0] == "list"
+    assert list(ro.r["length"](r_obj))[0] == 2
+    first = r_obj[0]
+    assert list(ro.r["class"](first))[0] == "numeric"
+    assert np.allclose(list(first), [0.0, 1.7])
+
+
+# --------------------------------------------------------------------------
+# Regression: r_to_py must NOT scalar-collapse semantic vectors, so a
+# length-1 vector field keeps its list container. Genuine scalars are still
+# unwrapped by name in the result marshaling.
+# --------------------------------------------------------------------------
+def _bb_single_kwargs():
+    """A one-component BB_data optimization (the length-1 vector case)."""
+    return dict(
+        outcome_name="pp3_oxytocin_mother",
+        outcome_type="binary",
+        glm_family="binomial",
+        intervention_components=["coaching_updt"],
+        center_characteristics=["birth_volume_100"],
+        center_characteristics_optimization_values=1.75,
+        intervention_lower_bounds=[1],
+        intervention_upper_bounds=[40],
+        cost_list=[[0, 1.7]],
+        outcome_goal=0.85,
+        outcome_goal_intention="maximize",
+        confidence_set_grid_step_size=[1],
+        quiet=True,
+    )
+
+
+def test_single_component_rec_int_is_list(bb_data):
+    """A single-component optimize() returns rec_int as a length-1 list of
+    floats (not a bare float); iterating and indexing both work."""
+    res = lago.optimize(data=bb_data, **_bb_single_kwargs())
+    rec = res["rec_int"]
+    assert isinstance(rec, list), f"rec_int should be a list, got {type(rec)}"
+    assert len(rec) == 1
+    assert all(isinstance(v, float) for v in rec)
+    # indexing and iteration must work (a bare float would crash both)
+    assert isinstance(res["rec_int"][0], float)
+    assert [v for v in res["rec_int"]] == rec
+    # the echoed length-1 bounds keep their list container too
+    assert isinstance(res["intervention_lower_bounds"], list)
+    assert res["intervention_lower_bounds"] == [1.0]
+    assert isinstance(res["intervention_upper_bounds"], list)
+    assert res["intervention_upper_bounds"] == [40.0]
+
+
+def test_multi_component_rec_int_unchanged(ro, bb_data):
+    """A 2-component run still returns a length-2 rec_int list and matches
+    direct R (the fix must not change the multi-component happy path)."""
+    res = lago.optimize(data=bb_data, **_bb_kwargs())
+    rec = res["rec_int"]
+    assert isinstance(rec, list)
+    assert len(rec) == 2
+    assert all(isinstance(v, float) for v in rec)
+
+    ro.globalenv["bb_data_r"] = _bridge.py_to_r(bb_data)
+    ro.r(
+        """
+        res_r <- LAGO::lago_optimization(
+          data = bb_data_r,
+          outcome_name = "pp3_oxytocin_mother",
+          outcome_type = "binary",
+          glm_family = "binomial",
+          intervention_components = c("coaching_updt", "launch_duration"),
+          center_characteristics = c("birth_volume_100"),
+          center_characteristics_optimization_values = 1.75,
+          intervention_lower_bounds = c(1, 1),
+          intervention_upper_bounds = c(40, 5),
+          cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+          outcome_goal = 0.85,
+          outcome_goal_intention = "maximize",
+          confidence_set_grid_step_size = c(1, 1),
+          quiet = TRUE
+        )
+        """
+    )
+    rec_int_r = list(ro.r("res_r$rec_int"))
+    est_r = list(ro.r("res_r$est_outcome_goal"))[0]
+    assert np.allclose(
+        np.array(res["rec_int"], dtype=float),
+        np.array(rec_int_r, dtype=float),
+    )
+    assert np.isclose(res["est_outcome_goal"], est_r)
+
+
+def test_scalar_fields_are_scalars(bb_data):
+    """Genuinely-scalar result fields stay python scalars, not length-1
+    lists, in both the single- and multi-component cases."""
+    for kwargs in (_bb_single_kwargs(), _bb_kwargs()):
+        res = lago.optimize(data=bb_data, **kwargs)
+        assert isinstance(res["est_outcome_goal"], float)
+        assert not isinstance(res["est_outcome_goal"], list)
+        assert isinstance(res["rec_int_cost"], float)
+        assert isinstance(res["confidence_set_size_percentage"], float)
+        # est_outcome_ci is a named c(lower, upper) -> stays a dict
+        assert isinstance(res["est_outcome_ci"], dict)
+        assert set(res["est_outcome_ci"].keys()) == {"lower", "upper"}
+
+
+def test_cost_list_nesting_preserved(ro, bb_data):
+    """r_to_py of an R list of length-1 vectors yields a list-of-lists (not a
+    flattened list), and a degree-0 cost_list [[5.0],[3.0]] round-trips with
+    its nesting intact through py_to_r as well."""
+    # r_to_py must NOT flatten list(c(5.0), c(3.0)) to [5.0, 3.0]
+    rlist = ro.r("list(c(5.0), c(3.0))")
+    assert _bridge.r_to_py(rlist) == [[5.0], [3.0]]
+    # a mixed-length list-of-vectors still round-trips
+    rlist2 = ro.r("list(c(0, 1.7), c(0, 8))")
+    assert _bridge.r_to_py(rlist2) == [[0.0, 1.7], [0.0, 8.0]]
+
+    # py_to_r of [[5.0],[3.0]] reaches R as a list of TWO length-1 numeric
+    # vectors (two constant-cost components), not one 2-coefficient vector.
+    r_obj = _bridge.py_to_r([[5.0], [3.0]])
+    assert list(ro.r["class"](r_obj))[0] == "list"
+    assert list(ro.r["length"](r_obj))[0] == 2
+    assert list(ro.r["length"](r_obj[0]))[0] == 1
+    assert list(ro.r["length"](r_obj[1]))[0] == 1
+    # full round-trip preserves nesting
+    assert _bridge.r_to_py(r_obj) == [[5.0], [3.0]]
+
+    # and it round-trips as the cost echo of a real single-component run
+    res = lago.optimize(
+        data=bb_data,
+        outcome_name="pp3_oxytocin_mother",
+        outcome_type="binary",
+        glm_family="binomial",
+        intervention_components=["coaching_updt"],
+        center_characteristics=["birth_volume_100"],
+        center_characteristics_optimization_values=1.75,
+        intervention_lower_bounds=[1],
+        intervention_upper_bounds=[40],
+        cost_list=[[0, 1.7]],
+        outcome_goal=0.85,
+        outcome_goal_intention="maximize",
+        confidence_set_grid_step_size=[1],
+        quiet=True,
+    )
+    echoed = res["cost_list_of_vectors"]
+    assert isinstance(echoed, list) and len(echoed) == 1
+    assert isinstance(echoed[0], list)
+    assert np.allclose(echoed[0], [0.0, 1.7])
+
+
+# --------------------------------------------------------------------------
+# 4. get_confidence_set basic call returns expected fields
+# --------------------------------------------------------------------------
+def test_get_confidence_set(bb_data):
+    opt = lago.optimize(data=bb_data, include_confidence_set=False, **{
+        k: v for k, v in _bb_kwargs().items()
+        if k != "confidence_set_grid_step_size"
+    })
+    predictors = bb_data[
+        ["coaching_updt", "launch_duration", "birth_volume_100"]
+    ]
+    cs = lago.get_confidence_set(
+        predictors_data=predictors,
+        intervention_components=["coaching_updt", "launch_duration"],
+        outcome_data=list(bb_data["pp3_oxytocin_mother"]),
+        fitted_model=opt["model"],
+        link="logit",
+        outcome_goal=0.85,
+        outcome_type="binary",
+        intervention_lower_bounds=[1, 1],
+        intervention_upper_bounds=[40, 5],
+        confidence_set_grid_step_size=[1, 1],
+        center_characteristics=["birth_volume_100"],
+        center_characteristics_optimization_values=1.75,
+        cost_list=[[0, 1.7], [0, 8]],
+        rec_int=opt["rec_int"],
+    )
+    assert isinstance(cs, dict)
+    assert set(cs.keys()) == {
+        "confidence_set_size_percentage", "rec_int_ci", "cs"
+    }
+    assert isinstance(cs["confidence_set_size_percentage"], float)
+    # rec_int_ci converts to a dict with lower/upper
+    assert isinstance(cs["rec_int_ci"], dict)
+    assert set(cs["rec_int_ci"].keys()) == {"lower", "upper"}
+    # the confidence set is a pandas DataFrame with the documented columns
+    assert isinstance(cs["cs"], pd.DataFrame)
+    for col in ("CI_lower_bound", "CI_upper_bound", "cost"):
+        assert col in cs["cs"].columns
+
+
+def test_optimize_confidence_set_is_dataframe(bb_data):
+    res = lago.optimize(data=bb_data, **_bb_kwargs())
+    assert isinstance(res["confidence_set_size_percentage"], float)
+    assert isinstance(res["cs"], pd.DataFrame)
+    assert isinstance(res["est_outcome_ci"], dict)
+
+
+# --------------------------------------------------------------------------
+# 5. visualize_cost: NOT launched (blocking browser app). We verify the
+#    wrapper builds the correct R call / converts args to the right R types.
+# --------------------------------------------------------------------------
+def test_visualize_cost_builds_r_call(ro):
+    kwargs = dict(
+        component_names=["Component 1", "Component 2"],
+        unit_costs=[0.5, 1.0],
+        default_cost_fxn_type="linear",
+        intervention_lower_bounds=[0, 0],
+        intervention_upper_bounds=[10, 10],
+    )
+    r_kwargs = _bridge.build_r_kwargs(kwargs)
+    assert list(ro.r["class"](r_kwargs["component_names"]))[0] == "character"
+    assert list(ro.r["class"](r_kwargs["unit_costs"]))[0] == "numeric"
+    assert list(r_kwargs["unit_costs"]) == [0.5, 1.0]
+    assert list(ro.r["class"](r_kwargs["default_cost_fxn_type"]))[0] == "character"
+    # the R function object exists and is callable
+    fn = _bridge._get_rfunc("visualize_cost")
+    assert fn is not None
+
+
+# --------------------------------------------------------------------------
+# lago_report renders an HTML file and returns its path
+# --------------------------------------------------------------------------
+def test_lago_report_returns_path(bb_data, tmp_path):
+    res = lago.optimize(data=bb_data, **_bb_kwargs())
+    out = str(tmp_path / "report.html")
+    path = lago.lago_report(res, output_file=out, title="pytest report")
+    assert isinstance(path, str)
+    import os
+    assert os.path.exists(path)
+    assert os.path.getsize(path) > 0
+
+
+# --------------------------------------------------------------------------
+# Conversion helpers
+# --------------------------------------------------------------------------
+def test_dataframe_roundtrip(bb_data):
+    r_df = _bridge.py_to_r(bb_data)
+    back = _bridge.r_to_py(r_df)
+    assert isinstance(back, pd.DataFrame)
+    assert back.shape == bb_data.shape
+
+
+def test_none_maps_to_r_null(ro):
+    r_null = _bridge.py_to_r(None)
+    assert list(ro.r["is.null"](r_null))[0] is True
+    assert _bridge.r_to_py(ro.NULL) is None


### PR DESCRIPTION
## Add a Python wrapper for the LAGO API

  Lets Python users call LAGO. A new package under `python/` (import as `lago`) embeds R through [`rpy2`](https://rpy2.github.io/) and calls the real exported R functions,
  so the results are exactly what the R package produces. No optimization logic is reimplemented in Python.

  ### What it does

  Wraps the four exported R functions:

  - **`lago.optimize(...)`** → `lago_optimization()`. Takes a pandas DataFrame for `data` and Python lists for the vector arguments; returns a dict (`rec_int` and the
  interval bounds as lists, the confidence set as a pandas DataFrame, the fitted model as the underlying R object).
  - **`lago.get_confidence_set(...)`** → `get_confidence_set()`.
  - **`lago.visualize_cost(...)`** → `visualize_cost()`. Launches the same interactive R Shiny + D3 browser app; Python triggers it and receives the cost list back when the
  app is closed.
  - **`lago.lago_report(...)`** → `lago_report()`. Returns the rendered HTML path.

  ```python
  import lago

  res = lago.optimize(
      data=df, outcome_name="Y", outcome_type="binary",
      intervention_components=["comp1", "comp2"],
      intervention_lower_bounds=[0, 0], intervention_upper_bounds=[10, 10],
      cost_list=[[0, 1.7], [0, 8]], outcome_goal=0.85,
  )
  res["rec_int"]           # -> Python list
  res["est_outcome_goal"]  # -> float
  ```

  ### Conversion

  Container type is a property of the R object, not its length: an R vector always becomes a Python list (so a single-component `rec_int` stays a length-1 list, not a bare
  float), an R list of vectors round-trips with its nesting intact, and only genuinely scalar result fields (e.g. `est_outcome_goal`) are unwrapped, by name.

  ### Isolation

  The Python package lives entirely under `python/` and is excluded from the R build via `.Rbuildignore` (`^python$`), so it does not affect the R package. The only R-side
  change is that one line.

  ### Honest caveat

  `rpy2` **embeds** R, so R and the installed LAGO R package are required. This gives Python users the LAGO API in Python syntax, not an R-free install. `visualize_cost()`
  opens a browser and blocks until the app is closed.

  ### Docs

  - Adds a "Using LAGO from Python" section (with example) to the top-level README.
  - Adds NEWS entries under 1.1.0 for the Python wrapper **and** the two prior features that were missing NEWS bullets: the Rcpp sandwich-variance kernel (#79) and the
  client-side D3 cost curves (#80).

  ### Tests

  - `python/tests/` (pytest): round-trip proof that `lago.optimize()`'s `rec_int` is numerically identical to direct-R `lago_optimization()`; scalar-vs-vector container
  shape (single- and multi-component); cost_list nesting; `get_confidence_set` fields.
  - **14 pytest pass.** `visualize_cost` is not auto-tested (it opens a blocking browser app); its arg construction is asserted, interactive use is manual.
  - R package unaffected: no R code, `DESCRIPTION`, `NAMESPACE`, or `man/` changes.