### PR TITLE
Add citation metadata, community health files and status badges

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^ISSUE_.*\.md$
 ^tests/js$
 ^python$
+^CITATION\.cff$

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,37 @@
+# Contributor Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Focusing on what is best for the community.
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and unwelcome sexual attention.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information without their explicit permission.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainer at abing@bu.edu. All complaints will be
+reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to LAGO
+
+Thanks for your interest in LAGO. Contributions of all kinds are welcome, from
+bug reports to documentation fixes to new features.
+
+## Reporting a bug
+
+Open an issue using the bug-report template. A good report includes:
+
+- what you ran (a minimal `lago_optimization()` / `get_confidence_set()` call),
+- what you expected and what happened instead,
+- the output of `sessionInfo()` and the LAGO version.
+
+A small reproducible example is the single most helpful thing you can provide.
+
+## Suggesting a feature
+
+Open an issue using the feature-request template and describe the use case, not
+just the mechanism: what analysis are you trying to run that LAGO does not yet
+support?
+
+## Making a change
+
+1. Fork the repository and create a branch off `main`.
+2. Make your change. Keep the existing style: run `styler::style_pkg()` and
+   `lintr::lint_package()` if you have them.
+3. Add or update tests under `tests/testthat/`. New behaviour needs a test that
+   fails without your change.
+4. Run the checks locally:
+   ```r
+   devtools::document()   # if you changed roxygen comments
+   devtools::test()       # NOT_CRAN=true runs the full suite
+   devtools::check()
+   ```
+5. Open a pull request against `main` and fill in the template.
+
+Continuous integration runs `R CMD check` on Linux, macOS and Windows, reports
+test coverage to Codecov, and runs the JavaScript math test for the cost
+curves. Please make sure the checks pass.
+
+## Code of Conduct
+
+By participating in this project you agree to abide by the
+[Code of Conduct](CODE_OF_CONDUCT.md).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Report something that is not working as expected
+title: ""
+labels: bug
+assignees: ""
+---
+
+**What happened**
+
+A clear description of the bug.
+
+**Reproducible example**
+
+The smallest `lago_optimization()` / `get_confidence_set()` / `visualize_cost()`
+call that shows the problem, ideally using a built-in dataset (`BB_data`,
+`BB_proportions`) or a small synthetic one.
+
+```r
+# your code here
+```
+
+**Expected behaviour**
+
+What you expected to happen instead.
+
+**Session info**
+
+<details>
+
+```r
+# paste the output of sessionInfo() here
+```
+
+</details>
+
+- LAGO version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest a capability or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**The use case**
+
+What analysis are you trying to run that LAGO does not yet support? Describe the
+problem, not just a proposed solution.
+
+**Proposed behaviour**
+
+What you would like LAGO to do, and how you imagine calling it.
+
+**Alternatives**
+
+Anything you currently do to work around this.
+
+**Additional context**
+
+Relevant references, related issues, or example data.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## What this changes
+
+A short description of the change and why.
+
+## Related issue
+
+Closes #
+
+## Checklist
+
+- [ ] Tests added or updated under `tests/testthat/` (new behaviour has a test
+      that fails without this change).
+- [ ] `devtools::document()` run if roxygen comments changed.
+- [ ] `devtools::check()` passes locally.
+- [ ] `NEWS.md` updated with a one-line entry if this is a user-facing change.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,52 @@
+cff-version: 1.2.0
+message: "If you use LAGO, please cite both the software and the methods paper below."
+title: "LAGO: Learn-As-you-GO Adaptive Trial Optimization"
+type: software
+version: 1.1.0
+license: GPL-3.0-only
+repository-code: "https://github.com/correspondMerchant/LAGO-R-Package"
+url: "https://correspondmerchant.github.io/LAGO-R-Package/"
+authors:
+  - family-names: Bing
+    given-names: Ante
+    email: abing@bu.edu
+  - family-names: Bui
+    given-names: Minh
+  - family-names: Cui
+    given-names: Jingyu
+# The methods paper to cite for the LAGO methodology the package implements.
+# Update this to the package's own software paper once it is published.
+preferred-citation:
+  type: article
+  title: "Learn-As-you-GO (LAGO) Trials: Optimizing Treatments and Preventing Trial Failure Through Ongoing Learning"
+  authors:
+    - family-names: Bing
+      given-names: Ante
+    - family-names: Spiegelman
+      given-names: Donna
+    - family-names: Nevo
+      given-names: Daniel
+    - family-names: Lok
+      given-names: Judith J.
+  journal: "Biometrics"
+  year: 2025
+  volume: 81
+  issue: 2
+  doi: "10.1093/biomtc/ujaf061"
+references:
+  - type: article
+    title: "Analysis of \"Learn-As-you-GO\" (LAGO) Studies"
+    authors:
+      - family-names: Nevo
+        given-names: Daniel
+      - family-names: Lok
+        given-names: Judith J.
+      - family-names: Spiegelman
+        given-names: Donna
+    journal: "Annals of Statistics"
+    year: 2021
+    volume: 49
+    issue: 2
+    start: 793
+    end: 819
+    doi: "10.1214/20-aos1978"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 
 <p align="center">
+  <a href="https://www.repostatus.org/#active"><img src="https://www.repostatus.org/badges/latest/active.svg" alt="Project Status: Active"></a>
+  <a href="https://lifecycle.r-lib.org/articles/stages.html#stable"><img src="https://img.shields.io/badge/lifecycle-stable-brightgreen.svg" alt="Lifecycle: stable"></a>
   <a href="https://github.com/correspondMerchant/LAGO-R-Package/actions/workflows/R-CMD-check.yaml"><img src="https://github.com/correspondMerchant/LAGO-R-Package/actions/workflows/R-CMD-check.yaml/badge.svg" alt="R-CMD-check"></a>
   <a href="https://app.codecov.io/gh/correspondMerchant/LAGO-R-Package"><img src="https://codecov.io/gh/correspondMerchant/LAGO-R-Package/branch/main/graph/badge.svg" alt="Codecov test coverage"></a>
   <a href="https://www.gnu.org/licenses/gpl-3.0"><img src="https://img.shields.io/badge/License-GPL%20v3-blue.svg" alt="License: GPL v3"></a>


### PR DESCRIPTION
- CITATION.cff: adds GitHub's "Cite this repository" button, pointing at the Biometrics 2025 LAGO methods paper as the preferred citation and the Annals of Statistics 2021 paper as a related reference. A comment marks where to swap in the package's own software paper once it is published. Excluded from the R build via .Rbuildignore (R uses inst/CITATION, not CITATION.cff).
- Community health files under .github/: CONTRIBUTING.md, a Contributor Covenant CODE_OF_CONDUCT.md, bug-report and feature-request issue templates, and a pull-request template. Already covered by the ^.github$ build ignore.
- README: add repostatus (active) and lifecycle (stable) badges.