### PR TITLE
Test/interaction and fit warning coverage

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # LAGO 1.1.0
 
+* Added tests for the interaction-terms optimization path and the outcome-model fit warnings, and excluded the interactive `visualize_cost()` app from the coverage figure so it reflects the testable R code.
+* Added a `CITATION.cff` so the repository can be cited, plus contributing guidelines, a code of conduct and issue/pull-request templates. (#86)
+* Added test-coverage reporting, cross-platform (macOS, Windows, Linux) continuous integration, project-status and coverage badges, and a social-preview card. (#83, #84, #85)
 * Added a Python wrapper (in `python/`, importable as `lago`) that calls LAGO through `rpy2`. (#81)
 * `visualize_cost()` now draws its cost curves client-side with D3, with hover read-outs, a draggable curve endpoint, and invalid-state highlighting. (#80)
 * The clustered variance estimator for logit outcomes is now computed by a compiled Rcpp kernel, so `Rcpp` is a new dependency. (#79)

--- a/R/visualize_cost.R
+++ b/R/visualize_cost.R
@@ -53,6 +53,15 @@
 #' visualize_cost(...)}. Closing the browser tab instead of using the button
 #' does not save the list.
 #'
+# nocov start
+# The body of visualize_cost() is an interactive Shiny app (UI definition plus
+# the server function and its nested plot helpers). It only runs inside a live
+# browser session, which the coverage instrumentation cannot drive, so counting
+# its lines only depresses the coverage figure without measuring anything. The
+# curve/drag math it relies on is tested separately by the standalone JavaScript
+# test (tests/js/test-cost-math.js, run in its own CI job), and the pure R
+# helpers below (compute_slider_range, format_coef) are outside this block and
+# are covered by tests/testthat/test-helpers.R.
 visualize_cost <- function(
     component_names,
     unit_costs,
@@ -674,6 +683,7 @@ visualize_cost <- function(
   # auto-printing the whole list to the console on close.
   invisible(shiny::runApp(shinyApp(ui, server)))
 }
+# nocov end
 
 # Compute a default slider range for a single cost-function coefficient.
 # The cost-function coefficients span very different scales (for a cubic cost

--- a/tests/testthat/test-fit-warnings.R
+++ b/tests/testthat/test-fit-warnings.R
@@ -1,0 +1,81 @@
+# Tests for the fit diagnostics in diagnose_model_fit(): the glm fit-warning
+# surfacing (separation signal captured during fitting) and the large-SE /
+# separation check. Both are exercised through a (quasi-)separation logistic
+# fixture, so the preconditions the checks key on are real and asserted here
+# rather than assumed.
+
+# A perfectly separated logistic design: y is 0 below a cutoff and 1 above it,
+# so a single predictor separates the classes completely. glm() then warns
+# "fitted probabilities numerically 0 or 1 occurred" during fitting and drives
+# the coefficient standard errors to enormous values, which is what both
+# diagnostics detect.
+separation_fixture <- function() {
+  x <- seq(-5, 5, length.out = 40)
+  y <- as.integer(x > 0)
+  data.frame(x = x, y = y)
+}
+
+# fit the fixture while capturing the warnings glm() emits, exactly as
+# outcome_model_fitting() does, so the captured vector is the fit_warnings the
+# diagnostic is fed.
+fit_with_captured_warnings <- function(d) {
+  fit_warnings <- character(0)
+  model <- withCallingHandlers(
+    glm(y ~ x, data = d, family = binomial(link = "logit")),
+    warning = function(w) {
+      fit_warnings <<- c(fit_warnings, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  list(model = model, fit_warnings = fit_warnings)
+}
+
+test_that("diagnose_model_fit surfaces glm fit warnings and flags large standard errors under separation", {
+  diagnose <- getFromNamespace("diagnose_model_fit", "LAGO")
+  d <- separation_fixture()
+  fit <- fit_with_captured_warnings(d)
+
+  # PRECONDITION 1: glm actually warned about separation during fitting, so
+  # the fit-warning surfacing has something real to surface.
+  expect_true(length(fit$fit_warnings) > 0)
+  expect_true(any(grepl(
+    "numerically 0 or 1", fit$fit_warnings, fixed = TRUE
+  )))
+
+  # PRECONDITION 2: the fit really does have an extremely large standard error
+  # (both large in absolute terms and relative to the estimate), so the
+  # large-SE check is not firing on a healthy fit.
+  se <- coef(summary(fit$model))[, 2]
+  est <- coef(summary(fit$model))[, 1]
+  large <- is.finite(se) & se > 1e3 & se > 100 * abs(est)
+  expect_true(any(large))
+
+  # capture every warning diagnose_model_fit() emits so the specific ones can
+  # be picked out (the fixture may also trip the non-significance warning).
+  ws <- character(0)
+  withCallingHandlers(
+    diagnose(
+      model = fit$model,
+      intervention_components = "x",
+      fit_warnings = fit$fit_warnings
+    ),
+    warning = function(w) {
+      ws <<- c(ws, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+
+  # the surfaced glm fit warning (lines ~176-182): names separation and echoes
+  # the captured glm message.
+  surfaced <- ws[grepl("may indicate an unreliable fit", ws)]
+  expect_length(surfaced, 1)
+  expect_match(surfaced, "separation")
+  expect_match(surfaced, "numerically 0 or 1")
+
+  # the large-SE / near-singular warning (lines ~214-221): names the affected
+  # coefficient (x).
+  large_se_warn <- ws[grepl("extremely large standard errors", ws)]
+  expect_length(large_se_warn, 1)
+  expect_match(large_se_warn, "separation or a near-singular fit")
+  expect_match(large_se_warn, "x")
+})

--- a/tests/testthat/test-interaction-terms.R
+++ b/tests/testthat/test-interaction-terms.R
@@ -1,0 +1,126 @@
+# End-to-end tests for the interaction-terms path
+# (include_interaction_terms = TRUE). These exercise the a:b component
+# multiplication in three places no other test reaches:
+#   - the grid_search interaction grid build in get_recommended_interventions()
+#   - the same build in the confidence-set grid in get_confidence_set()
+#   - the int_vector builder in shrinking_method() (unachievable goal)
+
+# Build data whose continuous outcome truly depends on a, b AND a*b, on the
+# identity link so the estimated outcome is the linear predictor and can be
+# pinned against an independent hand fit. The interaction column must be a
+# real column named "a:b" (its product), which is what the package fits.
+interaction_data <- function() {
+  set.seed(11)
+  grid <- expand.grid(a = 0:4, b = 0:4)
+  a <- rep(grid$a, times = 6)
+  b <- rep(grid$b, times = 6)
+  # true dependence on a, b, and the a*b interaction, plus small noise
+  y <- 1 + 0.5 * a + 0.3 * b + 0.2 * a * b + rnorm(length(a), 0, 0.4)
+  d <- data.frame(y = y, a = a, b = b)
+  d[["a:b"]] <- d$a * d$b
+  d
+}
+
+interaction_run <- function(...) {
+  args <- list(
+    data = interaction_data(),
+    outcome_name = "y",
+    outcome_type = "continuous",
+    glm_family = "gaussian",
+    link = "identity",
+    intervention_components = c("a", "b", "a:b"),
+    main_components = c("a", "b"),
+    include_interaction_terms = TRUE,
+    intervention_lower_bounds = c(0, 0),
+    intervention_upper_bounds = c(4, 4),
+    cost_list_of_vectors = list(c(0, 1), c(0, 1)),
+    optimization_method = "grid_search",
+    optimization_grid_search_step_size = c(1, 1),
+    confidence_set_grid_step_size = c(1, 1),
+    include_confidence_set = TRUE,
+    quiet = TRUE
+  )
+  ov <- list(...)
+  for (nm in names(ov)) args[nm] <- list(ov[[nm]])
+  do.call(lago_optimization, args)
+}
+
+# the fitted design the package uses. For two numeric regressors R's a:b term
+# is the product, so glm(y ~ a * b) is the same design the package fits from
+# the "a:b" column, and its coefficients are the ones the optimizer reads.
+# Held against the run's own estimated outcome below, this pins the a*b
+# multiplication rather than letting the package agree with itself.
+hand_interaction_outcome <- function(rec_int) {
+  d <- interaction_data()
+  m <- glm(y ~ a * b, data = d, family = gaussian(link = "identity"))
+  a_rec <- rec_int[1]
+  b_rec <- rec_int[2]
+  as.numeric(c(1, a_rec, b_rec, a_rec * b_rec) %*% coef(m))
+}
+
+test_that("interaction-terms run recommends over the MAIN components and the estimated outcome matches an independent a*b fit", {
+  # goal 3 is reachable on these bounds and leaves a non-empty confidence set,
+  # so both the recommendation grid and the confidence-set grid build the
+  # interaction columns and there is a real data.frame to assert on.
+  res <- suppressWarnings(suppressMessages(interaction_run(
+    outcome_goal = 3, outcome_goal_intention = "maximize"
+  )))
+
+  # the recommendation is over the two MAIN components, not the three
+  # intervention components (the interaction column is not a knob).
+  expect_length(res$rec_int, 2)
+  expect_true(all(res$rec_int >= c(0, 0)))
+  expect_true(all(res$rec_int <= c(4, 4)))
+  expect_true(is.finite(res$est_outcome_goal))
+
+  # INDEPENDENT hand computation: the estimated outcome at the recommendation
+  # is the linear predictor c(1, a, b, a*b) %*% coef of a fit computed here,
+  # not by the package.
+  expect_equal(
+    res$est_outcome_goal, hand_interaction_outcome(res$rec_int),
+    tolerance = 1e-8
+  )
+
+  # the confidence set carries the expected columns and its knob columns are
+  # the MAIN components (the interaction column is not reported as a knob).
+  expect_s3_class(res$cs, "data.frame")
+  expect_true(all(
+    c("CI_lower_bound", "CI_upper_bound", "cost") %in% names(res$cs)
+  ))
+  expect_true(all(c("a", "b") %in% names(res$cs)))
+  expect_false("a:b" %in% names(res$cs))
+  expect_gt(nrow(res$cs), 0)
+})
+
+test_that("an unachievable goal drives the interaction shrinking path", {
+  # a goal above the maximum achievable outcome on the bounds sends the run
+  # into shrinking_method(), whose create_interaction_vector() multiplies the
+  # a*b components (shrinking_method.R lines ~33-48). The goal-unreachable
+  # warning is the mechanism that reaches the path, so it is captured, not
+  # forced: we assert it fired AND keep the result for the value assertions.
+  ws <- character(0)
+  res <- withCallingHandlers(
+    suppressMessages(interaction_run(
+      outcome_goal = 100, outcome_goal_intention = "maximize",
+      include_confidence_set = FALSE
+    )),
+    warning = function(w) {
+      ws <<- c(ws, conditionMessage(w))
+      invokeRestart("muffleWarning")
+    }
+  )
+  # the unreachable-goal warning fired, which is what routed the run through
+  # the shrinking method.
+  expect_true(any(grepl("goal|reach|achiev", ws)))
+
+  expect_length(res$rec_int, 2)
+  expect_true(all(res$rec_int >= c(0, 0)))
+  expect_true(all(res$rec_int <= c(4, 4)))
+
+  # the shrinking-path estimated outcome is the linear predictor at the
+  # returned recommendation, held against the same independent a*b fit.
+  expect_equal(
+    res$est_outcome_goal, hand_interaction_outcome(res$rec_int),
+    tolerance = 1e-8
+  )
+})


### PR DESCRIPTION
## What this changes

  Tests for the `include_interaction_terms = TRUE` path and the fit-diagnostic
  warnings, excludes the interactive `visualize_cost()` Shiny body from coverage
  (80.7% → 94.7%), and brings NEWS current (this work + the merged #83–#86 polish
  PRs). No R behavior changes.

  ## Related issue

  Closes #

  ## Checklist

  - [x] Tests added or updated under `tests/testthat/`
  - [ ] `devtools::document()` — n/a, no roxygen changes
  - [x] `devtools::check()` passes locally
  - [x] `NEWS.md` updated