### PR TITLE
Clean up R CMD check items and refuse all-NA intervention components

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # LAGO 1.1.0
 
+* `visualize_cost()` now stores the returned cost list in the `lago_cost_list` option instead of assigning it to the global environment; retrieve it with `getOption("lago_cost_list")`.
 * Added tests for the interaction-terms optimization path and the outcome-model fit warnings, and excluded the interactive `visualize_cost()` app from the coverage figure so it reflects the testable R code.
 * Added a `CITATION.cff` so the repository can be cited, plus contributing guidelines, a code of conduct and issue/pull-request templates. (#86)
 * Added test-coverage reporting, cross-platform (macOS, Windows, Linux) continuous integration, project-status and coverage badges, and a social-preview card. (#83, #84, #85)

--- a/R/BB_data.R
+++ b/R/BB_data.R
@@ -26,7 +26,7 @@
 #'   \item{coach5}{Number of coaching vissts accrued divided by 5}
 #'   \item{coach3}{Number of coaching vissts accrued divided by 3}
 #' }
-#' @source \url{https://pubmed.ncbi.nlm.nih.gov/26271331/}
+#' @source \doi{10.1186/s13012-015-0309-y}
 #' @source \url{https://www.nejm.org/doi/full/10.1056/NEJMoa1701075}
 #'
 #' @examples

--- a/R/lago_optimization.R
+++ b/R/lago_optimization.R
@@ -232,7 +232,8 @@
 #'
 #' @examples
 #' # Basic case showing how to carry out the optimization with
-#' # a built-in data set.
+#' # a built-in data set. The confidence set is skipped here to keep this
+#' # example fast; the \donttest examples below show a full run with one.
 #' lago_optimization(
 #'   data = infert,
 #'   outcome_name = "case",
@@ -244,9 +245,13 @@
 #'   cost_list_of_vectors = list(c(0, 4), c(0, 1)),
 #'   outcome_goal = 0.5,
 #'   outcome_goal_intention = "maximize",
-#'   confidence_set_grid_step_size = c(1, 1)
+#'   include_confidence_set = FALSE
 #' )
 #'
+#' # Fuller examples, including the confidence-set grid search, which is
+#' # inherently slower. Wrapped in \donttest{} so they are still checkable
+#' # but do not run on every automated check.
+#' \donttest{
 #' lago_optimization(
 #'   data = BB_data,
 #'   outcome_name = "pp3_oxytocin_mother",
@@ -279,6 +284,7 @@
 #'   outcome_goal_intention = "maximize",
 #'   confidence_set_grid_step_size = c(1, 1)
 #' )
+#' }
 #'
 #' @export
 #' @importFrom utils head

--- a/R/validate_inputs.R
+++ b/R/validate_inputs.R
@@ -189,6 +189,29 @@ validate_inputs <- function(
       "must be columns in the data frame."
     ))
   }
+  # refuse any intervention component whose column is entirely NA. glm()'s
+  # internal na.omit drops every row in that case, and the fit dies with an
+  # opaque error ("Argument mu must be a nonempty numeric vector") that never
+  # names the component. This runs after the column-existence check above so
+  # data[[component]] is always a real column, and before the interaction-term
+  # backticks are added below so the names still match the data columns.
+  # all(is.na(col)) treats numeric, factor and character columns alike, so an
+  # all-NA component of any type is caught here rather than left to fail
+  # cryptically inside model fitting.
+  all_na_components <- intervention_components[vapply(
+    intervention_components,
+    function(component) all(is.na(data[[component]])),
+    logical(1)
+  )]
+  if (length(all_na_components) > 0) {
+    stop(paste0(
+      "The intervention component(s) ",
+      paste(all_na_components, collapse = ", "),
+      " are entirely NA, so glm() would drop every row and they ",
+      "cannot enter the model. Remove them from intervention_components ",
+      "or supply observed values."
+    ))
+  }
 
   # check if center_characteristics is a character vector type
   if (length(center_characteristics) > 0) {

--- a/R/visualize_cost.R
+++ b/R/visualize_cost.R
@@ -46,12 +46,13 @@
 #' copied from within the app.
 #'
 #' @details When the app is closed with the "Return list to R & close" button,
-#' the coefficient list is also assigned to \code{lago_cost_list} in the global
-#' environment (overwriting any existing object of that name) and a message
-#' reports this, so the list is available even when the app was launched with a
-#' bare \code{visualize_cost(...)} call rather than \code{cost_list <-
-#' visualize_cost(...)}. Closing the browser tab instead of using the button
-#' does not save the list.
+#' the coefficient list is also stored in the \code{lago_cost_list} option
+#' (overwriting any existing value) and a message reports this, so the list is
+#' available even when the app was launched with a bare
+#' \code{visualize_cost(...)} call rather than \code{cost_list <-
+#' visualize_cost(...)}. Retrieve it with
+#' \code{getOption("lago_cost_list")}. Closing the browser tab instead of using
+#' the button does not save the list.
 #'
 # nocov start
 # The body of visualize_cost() is an interactive Shiny app (UI definition plus
@@ -95,19 +96,20 @@ visualize_cost <- function(
   )
 
   # When the user closes the app with the "Return list to R & close" button, the
-  # quit observer saves the current cost list to `lago_cost_list` in the global
-  # environment and sets `saved` to TRUE. This on.exit then tells the user where
-  # it is. The flag (initialized locally here) is required so the message only
+  # quit observer saves the current cost list to the `lago_cost_list` option and
+  # sets `saved` to TRUE. This on.exit then tells the user where it is. The flag
+  # (initialized locally here) is required so the message only
   # prints on that button-close path: it must NOT fire on an early error or on a
   # browser tab-close / Esc, where no cost list was produced.
   saved <- FALSE
   on.exit(
     if (saved) {
       message(
-        "Your cost list has been saved to `lago_cost_list` in your global ",
-        "environment.\n",
+        "Your cost list has been saved to the `lago_cost_list` option.\n",
+        "Retrieve it with: cost_list <- getOption(\"lago_cost_list\")\n",
         "Use it with: ",
-        "lago_optimization(..., cost_list_of_vectors = lago_cost_list)"
+        "lago_optimization(..., cost_list_of_vectors = ",
+        "getOption(\"lago_cost_list\"))"
       )
     },
     add = TRUE
@@ -666,11 +668,15 @@ visualize_cost <- function(
     # captured (e.g. cost_list <- visualize_cost(...)) instead of only copied.
     observeEvent(input$quit_button, {
       cl <- current_cost_list()
-      # save into the global environment so the list is available even when the
-      # app was launched with a bare visualize_cost(...) call (no assignment).
-      # This overwrites any existing `lago_cost_list`; the on.exit message
-      # announces it. `saved` gates that message (see the on.exit near the top).
-      assign("lago_cost_list", cl, envir = globalenv())
+      # Store the list in the `lago_cost_list` option so it is available even
+      # when the app was launched with a bare visualize_cost(...) call (no
+      # assignment). Using options() rather than assigning into the global
+      # environment keeps this CRAN-clean (package code may not write to
+      # globalenv()) while preserving the convenience: the caller can retrieve
+      # it with getOption("lago_cost_list"). This overwrites any existing value;
+      # the on.exit message announces it. `saved` gates that message (see the
+      # on.exit near the top).
+      options(lago_cost_list = cl)
       saved <<- TRUE
       stopApp(cl)
     })

--- a/man/BB_data.Rd
+++ b/man/BB_data.Rd
@@ -31,7 +31,7 @@ A data frame with 6124 rows and 21 variables:
 }
 }
 \source{
-\url{https://pubmed.ncbi.nlm.nih.gov/26271331/}
+\doi{10.1186/s13012-015-0309-y}
 
 \url{https://www.nejm.org/doi/full/10.1056/NEJMoa1701075}
 }

--- a/man/LAGO-package.Rd
+++ b/man/LAGO-package.Rd
@@ -19,4 +19,20 @@ Useful links:
 }
 
 }
+\author{
+\strong{Maintainer}: Ante Bing \email{abing@bu.edu}
+
+Authors:
+\itemize{
+  \item Ante Bing \email{abing@bu.edu}
+  \item Minh Bui
+  \item Jingyu Cui
+}
+
+Other contributors:
+\itemize{
+  \item Mike Bostock (Author of the bundled D3 v7 library, inst/js/d3.v7.min.js) [copyright holder]
+}
+
+}
 \keyword{internal}

--- a/man/lago_optimization.Rd
+++ b/man/lago_optimization.Rd
@@ -318,7 +318,8 @@ This is the main entry point of the package.
 }
 \examples{
 # Basic case showing how to carry out the optimization with
-# a built-in data set.
+# a built-in data set. The confidence set is skipped here to keep this
+# example fast; the \donttest examples below show a full run with one.
 lago_optimization(
   data = infert,
   outcome_name = "case",
@@ -330,9 +331,13 @@ lago_optimization(
   cost_list_of_vectors = list(c(0, 4), c(0, 1)),
   outcome_goal = 0.5,
   outcome_goal_intention = "maximize",
-  confidence_set_grid_step_size = c(1, 1)
+  include_confidence_set = FALSE
 )
 
+# Fuller examples, including the confidence-set grid search, which is
+# inherently slower. Wrapped in \donttest{} so they are still checkable
+# but do not run on every automated check.
+\donttest{
 lago_optimization(
   data = BB_data,
   outcome_name = "pp3_oxytocin_mother",
@@ -365,5 +370,6 @@ lago_optimization(
   outcome_goal_intention = "maximize",
   confidence_set_grid_step_size = c(1, 1)
 )
+}
 
 }

--- a/man/visualize_cost.Rd
+++ b/man/visualize_cost.Rd
@@ -52,12 +52,13 @@ function lago_optimization().
 }
 \details{
 When the app is closed with the "Return list to R & close" button,
-the coefficient list is also assigned to \code{lago_cost_list} in the global
-environment (overwriting any existing object of that name) and a message
-reports this, so the list is available even when the app was launched with a
-bare \code{visualize_cost(...)} call rather than \code{cost_list <-
-visualize_cost(...)}. Closing the browser tab instead of using the button
-does not save the list.
+the coefficient list is also stored in the \code{lago_cost_list} option
+(overwriting any existing value) and a message reports this, so the list is
+available even when the app was launched with a bare
+\code{visualize_cost(...)} call rather than \code{cost_list <-
+visualize_cost(...)}. Retrieve it with
+\code{getOption("lago_cost_list")}. Closing the browser tab instead of using
+the button does not save the list.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-validate-inputs.R
+++ b/tests/testthat/test-validate-inputs.R
@@ -688,6 +688,112 @@ test_that("lago_optimization refuses an all-NA covariate with a clear message", 
 })
 
 
+# An intervention component whose column is entirely NA has the same problem as
+# an all-NA additional covariate: glm()'s internal na.omit drops every row and
+# the fit dies with the opaque "Argument mu must be a nonempty numeric vector"
+# error that never names the component. It is refused up front here, naming the
+# offender(s), by the same mechanism as the covariate refusal above. The tests
+# below pin that the refusal fires and names the component, catches an all-NA
+# column of any type, and stays silent on a partially-observed component.
+
+test_that("an all-NA intervention component is refused, naming it", {
+  di <- mtcars
+  di$allna <- NA_real_
+  # precondition: the column really is entirely NA, so the test is not vacuous
+  expect_true(all(is.na(di$allna)))
+  expect_error(
+    call_vi(data = di, intervention_components = c("gear", "allna")),
+    "allna")
+  expect_error(
+    call_vi(data = di, intervention_components = c("gear", "allna")),
+    "entirely NA")
+})
+
+test_that("two all-NA intervention components are both named in one error", {
+  di <- mtcars
+  di$allna1 <- NA_real_
+  di$allna2 <- NA_real_
+  # precondition: both columns are entirely NA
+  expect_true(all(is.na(di$allna1)) && all(is.na(di$allna2)))
+  # one stop() listing both offenders together, alongside a valid component
+  err <- tryCatch(
+    call_vi(data = di,
+            intervention_components = c("allna1", "gear", "allna2"),
+            intervention_lower_bounds = c(0, 0, 0),
+            intervention_upper_bounds = c(10, 10, 10),
+            cost_list_of_vectors = list(c(0, 4), c(4, 6), c(0, 1))),
+    error = conditionMessage)
+  expect_match(err, "allna1")
+  expect_match(err, "allna2")
+})
+
+test_that("an all-NA factor or character intervention component is refused", {
+  # is.na() works on factor and character columns too, so the check catches an
+  # all-NA column of any type and does not itself error on the non-numeric one
+  di <- mtcars
+  di$allna_fac <- factor(rep(NA_character_, nrow(di)), levels = c("a", "b"))
+  expect_true(all(is.na(di$allna_fac)))
+  expect_error(
+    call_vi(data = di, intervention_components = c("gear", "allna_fac")),
+    "allna_fac")
+
+  di2 <- mtcars
+  di2$allna_chr <- NA_character_
+  expect_true(all(is.na(di2$allna_chr)))
+  expect_error(
+    call_vi(data = di2, intervention_components = c("gear", "allna_chr")),
+    "allna_chr")
+})
+
+test_that("an intervention component with some but not all NA is not refused", {
+  # negative control: the refusal is narrow. A component with SOME NAs is a
+  # legitimate input glm() can still fit, so this must pass the validator.
+  di <- mtcars
+  di$some_na <- di$gear
+  di$some_na[1] <- NA
+  # precondition: some NA, but not all
+  expect_true(anyNA(di$some_na) && !all(is.na(di$some_na)))
+  expect_no_error(
+    call_vi(data = di, intervention_components = c("gear", "some_na")))
+})
+
+test_that("lago_optimization refuses an all-NA intervention component clearly", {
+  # END-TO-END: the same all-NA intervention component that dies with an opaque
+  # "Argument mu must be a nonempty numeric vector" error deep in model fitting
+  # on the unfixed source is now refused up front by the input validator, so
+  # the caller sees a message that names the component and says why. Fails on
+  # the unfixed source, where the run reaches glm() and returns the cryptic
+  # error instead.
+  bbp <- as.data.frame(BB_proportions)
+  bbp$allna <- NA_real_
+  # precondition: the component really is entirely NA
+  expect_true(all(is.na(bbp$allna)))
+  run <- function() {
+    suppressWarnings(suppressMessages(lago_optimization(
+      data = bbp,
+      outcome_name = "EBP_proportions",
+      outcome_type = "continuous",
+      glm_family = "quasibinomial",
+      link = "logit",
+      intervention_components = c("coaching_updt", "allna"),
+      intervention_lower_bounds = c(1, 1),
+      intervention_upper_bounds = c(40, 5),
+      cost_list_of_vectors = list(c(0, 1.7), c(0, 8)),
+      outcome_goal = 0.85,
+      include_confidence_set = FALSE,
+      quiet = TRUE
+    )))
+  }
+  # the new message: names the component and says why it cannot enter the model
+  expect_error(run(), "allna")
+  expect_error(run(), "entirely NA")
+  # and NOT the opaque model-fitting errors the missing guard produced. Both
+  # assertions fail on the unfixed source, where run() returns exactly these.
+  expect_error(run(), "^(?!.*nonempty numeric).*$", perl = TRUE)
+  expect_error(run(), "^(?!.*model fitting step).*$", perl = TRUE)
+})
+
+
 # --- Group 4: bounds, costs, optimization method, grid step -----------------
 
 test_that("intervention_lower_bounds must be numeric", {


### PR DESCRIPTION
 ## What this changes

  Cleans up the actionable R CMD check items and fixes a residual bug carried over
  from #77.

  - Refuses an intervention component whose column is entirely `NA`, in
    `validate_inputs()`, naming the offender. Previously such a column made
    `glm()`'s `na.omit` drop every row and the run died with the opaque
    "Argument mu must be a nonempty numeric vector". #77 fixed this for additional
    covariates; this extends the same refusal to intervention components.
  - `visualize_cost()` now stores the returned cost list in the `lago_cost_list`
    option (`getOption("lago_cost_list")`) instead of assigning it to the global
    environment, which R CMD check flags. The return contract is unchanged.
  - Speeds up the `lago_optimization()` example so it no longer trips the >5s
    examples NOTE (the `infert` example drops the confidence set; the heavier
    BetterBirth examples move to `\donttest{}`).
  - Cites the `BB_data` source by DOI instead of a bare PubMed URL.

  `R CMD check --as-cran` drops from 3 NOTEs to 1. The remaining name-clash ERROR
  (existing `lago` on CRAN, a naming decision), qpdf WARNING and `-march=nocona`
  NOTE are a maintainer decision and local-toolchain artifacts, out of scope here.

  ## Related issue

  Closes #

  ## Checklist

  - [x] Tests added or updated under `tests/testthat/` (all-NA intervention-component refusal; fails without this change)
  - [x] `devtools::document()` run (regenerated the affected `man/*.Rd`)
  - [x] `devtools::check()` passes locally (the 3 targeted items are gone)
  - [x] `NEWS.md` updated (the `visualize_cost()` `lago_cost_list` behavior change)